### PR TITLE
Remove extraneous ? in chapter template

### DIFF
--- a/CHAPTER_TEMPLATE.md
+++ b/CHAPTER_TEMPLATE.md
@@ -18,7 +18,7 @@
 ## Checklist
 > this can be done at the end or maybe as a separate checklist exercise, but please do note things down here as you go
 
-## What to learn next?
+## What to learn next
 > recommended next chapters that are a good next step up
 
 ## Further reading


### PR DESCRIPTION
I don't think the ? at the end of the "What to learn next" section is right, since it's not a question.

This is literally a single character change. I'm making a pull request because the version control chapter is nearly ready for merging to master and I want it to be consistent with the template.



