### PR TITLE
Move glossary

### DIFF
--- a/CHAPTER_TEMPLATE.md
+++ b/CHAPTER_TEMPLATE.md
@@ -9,9 +9,6 @@
 ## Prerequisites / recommended skill level
 > other chapters that should have been read before or content you should be familiar with before you read this
 
-### Definitions/glossary
-> Link to the glossary here or copy in key concepts/definitions that readers should be aware of to get the most out of this chapter
-
 ## Chapter content
 > depending on the content, this might be more structured, e.g. with exercises, gotcha sections etc
 
@@ -24,6 +21,9 @@
 ## Further reading
 > top 3/5 resources to read on this topic (if they weren't licensed so we could include them above already) at the top, maybe in their own box/in bold.
 > less relevant/favourite resources in case someone wants to dig into this in detail
+
+## Definitions/glossary
+> Link to the glossary here or copy in key concepts/definitions that readers should be aware of to get the most out of this chapter
 
 ## Bibliography
 > Credit/urls for any materials that form part of the chapter's text.


### PR DESCRIPTION
Move the glossary section to just above the bibliography. This follows from discussion with @LouiseABowler and @pherterich on the version control chapter pull request.