### PR TITLE
[BUG] Fixing default branch name in jupyterbook config

### DIFF
--- a/book/website/_config.yml
+++ b/book/website/_config.yml
@@ -46,6 +46,7 @@ launch_buttons:
 repository:
   url                       : https://github.com/alan-turing-institute/the-turing-way  # The URL to your book's repository
   path_to_book              : "book/website"  # A path to your book's folder, relative to the repository root.
+  branch                    : main
 
 #######################################################################################
 # Advanced and power-user settings
@@ -53,6 +54,6 @@ sphinx:
   extra_extensions          :  # A list of extra extensions to load by Sphinx.
   config                    :  # key-value pairs to directly over-ride the Sphinx configuration
     language                : en
-    
+
 bibtex_bibfiles:
     - _bibliography/references.bib


### PR DESCRIPTION
The default branch name is `master` in the configuration of jupyterbook, but it was inherited rather than listed in our config file, thus my grep didn't find it in #2134  

Thank you @zeke for pointing out the bug. I didn't know at first why I didn't spot this, so could not advise how you could help. If you run into into any broken URLs after we merge this PR, please feel free to open a PR that fixes them, I  don't expect any other cases where they are inherited from configs rather than hard-wired in the source files (and thus ideally we should have #2143)