### PR TITLE
Turning off the alphabetical representation of the contributors table

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -6,7 +6,7 @@
   "contributorsPerLine": 7,
   "badgeTemplate": "[![All Contributors](https://img.shields.io/badge/all_contributors-<%= contributors.length %>-orange.svg)](#contributors)",
   "skipCi": false,
-  "contributorsSortAlphabetically": true,
+  "contributorsSortAlphabetically": false,
   "contributors": [
     {
       "login": "rainsworth",


### PR DESCRIPTION
### Summary

- Current issue: it gets a messy conflict [if two contribution requests are added simultaneously](https://github.com/alan-turing-institute/the-turing-way/pull/2676#issuecomment-1266198064) (See section "**PLEASE NOTE: Only one contributor can be added with the bot at a time!**" on [CONTRIBUTING.md](https://github.com/alan-turing-institute/the-turing-way/blob/main/CONTRIBUTING.md))
- One reason for this is the that contributors table is a html table, and inserting something new in the middle [shifts everything in the second half onwards](https://github.com/alan-turing-institute/the-turing-way/pull/2679/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5).  
- One partial (and hopefully minimally breaking) fix for this might be turning off the alphabetical representation of the contributors table. I assume then that the new contributor would just get added to the end.
- _(Noted while writing this PR...)_ However, it looks like it was a conscious choice to turn on the alphabetical representation (https://github.com/alan-turing-institute/the-turing-way/pull/1028)
- Would someone who was involved in that PR (@KirstieJane / @malvikasharan / @alexwlchan) be able to advise what the rationale for that change was?
- In the meantime I'll keep this as a draft PR, and try to think about whether there is a more complete fix (having the table be produced in a way that doesn't rewrite much of the previous table when a single new contributor is added) that we could perhaps contribute upstream.
- _Note: there would still be a merge conflict if two people were added simultaneously, because [the .all-contributorsrc file](https://github.com/alan-turing-institute/the-turing-way/blob/main/.all-contributorsrc) is also edited in a way that causes conflicts._
