### PR TITLE
add alternative text descriptions for images in Testing

### DIFF
--- a/book/website/reproducible-research/testing.md
+++ b/book/website/reproducible-research/testing.md
@@ -25,14 +25,14 @@ Here's a couple of illustrations exemplifying of why should write tests:
 ```{figure}  ../figures/testing-motivation1.*
 ---
 name: testing-motivation1
-alt: Headline of a December 2006 news article by Greg Miller, published in Science, titled "A Scientist's Nightmare: Software Problem Leads to Five Retractions"
+alt: Headline of a December 2006 news article by Greg Miller, published in Science, titled "A Scientist's Nightmare\: Software Problem Leads to Five Retractions"
 ---
 ```
 
 ```{figure}  ../figures/testing-motivation2.*
 ---
 name: testing-motivation2
-alt: Short news article  by Lisa Grossman, published on Wired.com in November 2010, describing an inconsistency between the units of force expected as output and input of two pieces of software that resulted in the loss of a weather satellite when it reached its destination at Mars. The piece is titled "November 10, 1999: Metric Math Mistake Muffed Mars Meteorology Mission."
+alt: Short news article  by Lisa Grossman, published on Wired.com in November 2010, describing an inconsistency between the units of force expected as output and input of two pieces of software that resulted in the loss of a weather satellite when it reached its destination at Mars. The piece is titled "November 10, 1999\: Metric Math Mistake Muffed Mars Meteorology Mission."
 ---
 ```
 

--- a/book/website/reproducible-research/testing.md
+++ b/book/website/reproducible-research/testing.md
@@ -25,14 +25,14 @@ Here's a couple of illustrations exemplifying of why should write tests:
 ```{figure}  ../figures/testing-motivation1.*
 ---
 name: testing-motivation1
-alt: Headline of a December 2006 news article by Greg Miller, published in Science, titled "A Scientist's Nightmare: Software Problem Leads to Five Retractions"
+alt: "Headline of a December 2006 news article by Greg Miller, published in Science, titled A Scientist's Nightmare: Software Problem Leads to Five Retractions"
 ---
 ```
 
 ```{figure}  ../figures/testing-motivation2.*
 ---
 name: testing-motivation2
-alt: Short news article  by Lisa Grossman, published on Wired.com in November 2010, describing an inconsistency between the units of force expected as output and input of two pieces of software that resulted in the loss of a weather satellite when it reached its destination at Mars. The piece is titled "November 10, 1999: Metric Math Mistake Muffed Mars Meteorology Mission."
+alt: "News article  by Lisa Grossman, published on Wired.com in November 2010, describing an inconsistency between the units of force expected as output and input of two pieces of software that resulted in the loss of a weather satellite when it reached its destination at Mars. The piece is titled November 10, 1999: Metric Math Mistake Muffed Mars Meteorology Mission"
 ---
 ```
 

--- a/book/website/reproducible-research/testing.md
+++ b/book/website/reproducible-research/testing.md
@@ -25,14 +25,14 @@ Here's a couple of illustrations exemplifying of why should write tests:
 ```{figure}  ../figures/testing-motivation1.*
 ---
 name: testing-motivation1
-alt: Headline of a December 2006 news article by Greg Miller, published in Science, titled "A Scientist's Nightmare\: Software Problem Leads to Five Retractions"
+alt: Headline of a December 2006 news article by Greg Miller, published in Science, titled "A Scientist's Nightmare: Software Problem Leads to Five Retractions"
 ---
 ```
 
 ```{figure}  ../figures/testing-motivation2.*
 ---
 name: testing-motivation2
-alt: Short news article  by Lisa Grossman, published on Wired.com in November 2010, describing an inconsistency between the units of force expected as output and input of two pieces of software that resulted in the loss of a weather satellite when it reached its destination at Mars. The piece is titled "November 10, 1999\: Metric Math Mistake Muffed Mars Meteorology Mission."
+alt: Short news article  by Lisa Grossman, published on Wired.com in November 2010, describing an inconsistency between the units of force expected as output and input of two pieces of software that resulted in the loss of a weather satellite when it reached its destination at Mars. The piece is titled "November 10, 1999: Metric Math Mistake Muffed Mars Meteorology Mission."
 ---
 ```
 

--- a/book/website/reproducible-research/testing.md
+++ b/book/website/reproducible-research/testing.md
@@ -32,7 +32,7 @@ alt: "Headline of a December 2006 news article by Greg Miller, published in Scie
 ```{figure}  ../figures/testing-motivation2.*
 ---
 name: testing-motivation2
-alt: "News article  by Lisa Grossman, published on Wired.com in November 2010, describing an inconsistency between the units of force expected as output and input of two pieces of software that resulted in the loss of a weather satellite when it reached its destination at Mars. The piece is titled November 10, 1999: Metric Math Mistake Muffed Mars Meteorology Mission"
+alt: "News article by Lisa Grossman, published on Wired.com in November 2010, describing an inconsistency between the units of force expected as output and input of two pieces of software that resulted in the loss of a weather satellite when it reached its destination at Mars. The piece is titled November 10, 1999: Metric Math Mistake Muffed Mars Meteorology Mission"
 ---
 ```
 

--- a/book/website/reproducible-research/testing.md
+++ b/book/website/reproducible-research/testing.md
@@ -25,14 +25,14 @@ Here's a couple of illustrations exemplifying of why should write tests:
 ```{figure}  ../figures/testing-motivation1.*
 ---
 name: testing-motivation1
-alt:
+alt: Headline of a December 2006 news article by Greg Miller, published in Science, titled "A Scientist's Nightmare: Software Problem Leads to Five Retractions"
 ---
 ```
 
 ```{figure}  ../figures/testing-motivation2.*
 ---
 name: testing-motivation2
-alt:
+alt: Short news article  by Lisa Grossman, published on Wired.com in November 2010, describing an inconsistency between the units of force expected as output and input of two pieces of software that resulted in the loss of a weather satellite when it reached its destination at Mars. The piece is titled "November 10, 1999: Metric Math Mistake Muffed Mars Meteorology Mission."
 ---
 ```
 

--- a/book/website/reproducible-research/testing/testing-exceptions.md
+++ b/book/website/reproducible-research/testing/testing-exceptions.md
@@ -91,7 +91,7 @@ The result may look like this:
 ```{figure} ../../figures/eyeball-test1.*
 ---
 name: eyeball-test1
-alt:
+alt: Scatter plot of water level in a reservoir measured at regular intervals over 24 hours, where level remains fairly constant.
 ---
 ```
 
@@ -100,7 +100,7 @@ On a day with rain it might look like this:
 ```{figure} ../../figures/eyeball-test2.*
 ---
 name: eyeball-test2
-alt:
+alt: Scatter plot of water level in a reservoir measured at regular intervals over 24 hours, where level increases steadily between 6am and 9pm before dropping slightly in the last 3-hour period.
 ---
 ```
 
@@ -109,7 +109,7 @@ and on a dry day it might look like this:
 ```{figure} ../../figures/eyeball-test3.*
 ---
 name: eyeball-test3
-alt:
+alt: Scatter plot of water level in a reservoir measured at regular intervals over 24 hours, where level decreases steadily.
 ---
 ```
 
@@ -118,7 +118,7 @@ All of these outputs look very different but are valid. However, if a researcher
 ```{figure} ../../figures/eyeball-test-error.*
 ---
 name: eyeball-test-error
-alt:
+alt: Scatter plot of water level in a reservoir measured at regular intervals over 24 hours, where fairly constant levels flank one very high measurement taken at midday.
 ---
 ```
 


### PR DESCRIPTION
### Summary

Fixes #3238 by adding alternative text descriptions for images in _Guide for Reproducible Research_ -> _Code Testing_

### List of changes proposed in this PR (pull-request)

- [x] add alt-text for images in `reproducible-research/testing.md`
- [x] add alt-text for images in `reproducible-research/testing/testing-exceptions.md`
    - alt-text descriptions in this file based on guidance provided in https://nightingaledvs.com/writing-alt-text-for-data-visualization/

### What should a reviewer concentrate their feedback on?

- [ ] Do the alt-text descriptions convey the purpose of the images in the context of their respective sections?
- [ ] Could they be improved, either by making them clearer or by adding more detail that would be important for someone who cannot view the image itself?

### Acknowledging contributors

<!-- Please select the correct box -->

- [ ] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/main/README.md#contributors) in the README file.
- [x] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/main/README.md#contributors) in the README file: @tobyhodges 
