### PR TITLE
Change Learning Lab Github link

### DIFF
--- a/book/website/reproducible-research/vcs/vcs-resources.md
+++ b/book/website/reproducible-research/vcs/vcs-resources.md
@@ -14,7 +14,7 @@ They also ease using version control by keeping changes neat and localised.
 
 - A free and very in-depth book on Git's myriad of features can be found [here](https://Git-scm.com/book/en/v2).
 - A useful Git cheat sheet can be found [here](https://education.github.com/git-cheat-sheet-education.pdf).
-- Interactive tutorials for familiarising yourself with GitHub can be found at [https://lab.github.com/](https://lab.github.com/).
+- Interactive tutorials for familiarising yourself with GitHub can be found at [https://skills.github.com/](https://skills.github.com/).
 - Interactive tutorials for DataLad can be found at [handbook.datalad.org](http://handbook.datalad.org), and a walk-through of git-annex can be found at [git-annex.branchable.com/walkthrough/](https://git-annex.branchable.com/walkthrough/).
 - An article on syncing a fork of a repository to keep it up-to-date with the upstream repository can be found [here](https://help.github.com/en/articles/syncing-a-fork).
 - If you wish to do it all in the browser itself, instructions to do so can be found [here](https://github.com/KirstieJane/STEMMRoleModels/wiki/Syncing-your-fork-to-the-original-repository-via-the-browser).


### PR DESCRIPTION

### Summary

Github learning lab link is broken

> If you've used Learning Lab, we recommend trying a GitHub Skills course for the latest content and an updated learning experience backed by GitHub Actions


From: https://github.blog/changelog/2022-09-01-deprecating-learning-lab/


### List of changes proposed in this PR (pull-request)

- [x]  Change link



### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

- [x] Everything looks ok?


### Acknowledging contributors

<!-- Please select the correct box -->

- [ ] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/main/README.md#contributors) in the README file.
- [x] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/main/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
