### PR TITLE
Add NHS England as employer for /collaboration/research-infrastructure-roles/data-wrangler.html

### DIFF
--- a/book/website/collaboration/research-infrastructure-roles/data-wrangler.md
+++ b/book/website/collaboration/research-infrastructure-roles/data-wrangler.md
@@ -83,8 +83,11 @@ Here are some examples of places that employ Data Wranglers in the UK:
    * Project: [The Artificial Intelligence for Multiple Long-Term Conditions, Research Support Facility](https://www.turing.ac.uk/research/research-projects/ai-multiple-long-term-conditions-research-support-facility)
 * [EMBL's European Bioinformatics Institute](https://www.ebi.ac.uk/)
    * Project: [The Human Cell Atlas](https://www.humancellatlas.org/)
+* NHS England
+   * Project: [NHSE Secure Data Environment](https://digital.nhs.uk/services/secure-data-environment-service)
+   * Description: NHS England Data Wranglers support a wide range of research done by health and social care organisations using the National Secure Data Environment (NSDE) to ensure the data is in an accessible format. They also help suggest and test platform improvements, produce *"here's one I made earlier"* analyses, to save users time and advise on data in a technical capacity.
 
-_Please get in touch if you know of other organisations that you would like to add to this list. This list, and this Data Wrangler page in general, is focused around Data Wrangler roles within an  academic research context, but they will also exist within an industry context._
+_Please get in touch if you know of other organisations that you would like to add to this list. This list, and this Data Wrangler page in general, started off with a focus on Data Wrangler roles within an  academic research context, but these roles will also exist within other contexts._
 
 (cl-infrastructure-data-wranglers-summary)=
 ## Data Wranglers: Summary


### PR DESCRIPTION
<!--
Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
-->
### Summary

<!-- Describe the problem you're trying to fix in this pull request. Please reference any related issue and use fixes/close to automatically close them, if pertinent. For example: "Fixes #58", or "Addresses (but does not close) #238". -->

Fixes #3286 

Adding a new employer to the Data Wrangler page in the Research Infrastructure Section 

### List of changes proposed in this PR (pull-request)

<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

- Added suggested text by @AdamHollings in #3286 

### What should a reviewer concentrate their feedback on?

- [ ] For @AdamHollings  - I included your text but tweaked it slightly to make it a bit shorter. Is that okay?
- [ ] For @Arielle-Bennett - Does it look weird that only one employer has this description section. If yes, we could remove it. I think it is okay to leave in and fill in descriptions for the other ones later, but open either way

### Acknowledging contributors

<!-- Please select the correct box -->

- [ ] All contributors to this pull request are already named in the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file.
- [x] The following people should be added to the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->  @AdamHollings
