### PR TITLE
Alternative for broken link

### DIFF
--- a/book/website/communication/citable/citable-resources.md
+++ b/book/website/communication/citable/citable-resources.md
@@ -31,5 +31,5 @@
 - [FORCE11 Data Citation principles](https://www.force11.org/datacitationprinciples)
 - [FORCE11 Software Citation principles](https://www.force11.org/software-citation-principles)
 - [Getting Started with your ORCID record](https://support.orcid.org/hc/en-us/articles/360006896894-Getting-started-with-your-ORCID-record)
-- [Making software citeable](https://guide.esciencecenter.nl/citable_software/making_software_citable.html)
+- [Making software citeable](https://guide.esciencecenter.nl/#/best_practices/documentation?id=doi-or-pid)
 - [OpenAIRE Guide on Person Identifiers](https://www.openaire.eu/how-can-identifiers-improve-the-dissemination-of-your-research-outputs)

--- a/book/website/communication/citable/citable-resources.md
+++ b/book/website/communication/citable/citable-resources.md
@@ -31,5 +31,5 @@
 - [FORCE11 Data Citation principles](https://www.force11.org/datacitationprinciples)
 - [FORCE11 Software Citation principles](https://www.force11.org/software-citation-principles)
 - [Getting Started with your ORCID record](https://support.orcid.org/hc/en-us/articles/360006896894-Getting-started-with-your-ORCID-record)
-- [Making software citeable](https://guide.esciencecenter.nl/#/best_practices/documentation?id=doi-or-pid)
+- [Making software citeable](https://the-turing-way.netlify.app/communication/citable/citable-cite#citing-software)
 - [OpenAIRE Guide on Person Identifiers](https://www.openaire.eu/how-can-identifiers-improve-the-dissemination-of-your-research-outputs)


### PR DESCRIPTION
### Summary

The website doesn't refer to the specified page anymore https://guide.esciencecenter.nl/#/best_practices/documentation?id=software-citation

Fixes #NA

### List of changes proposed in this PR (pull-request)

* Just the one link

### What should a reviewer concentrate their feedback on?

- [ ] Everything looks ok?


### Acknowledging contributors

- [ ] All contributors to this pull request are already named in the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
