### PR TITLE
Rationalise cross referencing examples

### DIFF
--- a/book/website/community-handbook/style/style-crossref.md
+++ b/book/website/community-handbook/style/style-crossref.md
@@ -80,54 +80,13 @@ This label can be created in the corresponding file for the suggested section na
 
 ### Examples of cross-referencing
 
-**Examples for cross-referencing sections of chapters and subchapters**
-
+Here we provide examples of how to cross-reference chapters, sections of chapters and subchapters.
 We will use examples for the chapters in the "Reproducible Research" guide located in the `book/website` directory.
 
-**_Case 1_**: When you cross-reference a section of the chapter within the same file _before_ a label has been created.
+**_Example 1_**: Cross-referencing a chapter or subchapter (chapter/subchapter).
 
-Taking the previous example of `rr-overview-resources-addmaterial`, we can use this label to cross-reference
-it in an earlier section within the same file using the following:
-
-```
-{ref}`rr-overview-resources-addmaterial`
-```
-
-This will appear in the online book like so: {ref}`rr-overview-resources-addmaterial`.
-
-**_Case 2_**: When you cross-reference a section of the chapter within the same file _after_ a label has been created.
-
-In the same subchapter "Resources", we have created a label `rr-overview-resources-reading` for the section "Further Reading".
-We can cross-reference it in a later section within the same file using the following:
-
-```
-{ref}`rr-overview-resources-reading`
-```
-
-It will appear in your chapter like this: {ref}`rr-overview-resources-reading`.
-
-**_Case 3_**: When you cross-reference a section of a chapter in a different file (chapter) before or after a label has been created.
-
-In the subchapter "Definitions" of the "Overview" chapter, we have created a label
-`rr-overview-definitions` for the section "Table of definitions for reproducibility".
-
-We can cross-reference it in a different subchapter or chapter.
-In this case, let's cross-reference it in the landing (main) page of the "Overview" chapter by using the following:
-
-```
-{ref}`rr-overview-definitions`
-```
-
-It will appear in your chapter like this: {ref}`rr-overview-definitions`.
-
-Though we are demonstrating this example for subchapters within the same chapter ("Overview"), the similar syntaxes can be used for cross-referencing in other chapters within the book.
-
-**Examples for Cross referencing chapters and subchapters**
-
-**_Case 4_**: Cross-referencing a chapter or subchapter in a different file (chapter/subchapter) before or after a label has been created.
-
-For example, in the landing page of the chapter "Open Research", we have created a label `rr-open`.
-We can cross-reference it in the section "What to learn next?" in a different subchapter "Resources" of the "Overview" chapter by using the following:
+On the landing page of the chapter "Open Research", we have created a label `rr-open`.
+We can cross-reference it at any other point in the book by using the following:
 
 ```
 {ref}`rr-open`
@@ -135,7 +94,22 @@ We can cross-reference it in the section "What to learn next?" in a different su
 
 It will appear in your chapter like this: {ref}`rr-open`.
 
-Though we are demonstrating this example for cross-referencing chapters and subchapters across the book, the same syntax can be used for cross-referencing subchapters within the same chapter.
+It doesn't matter whether the label appears before or after the reference, or even on a completely different page.
+The same syntax can be used whether you are cross-referencing chapters and subchapters within the same chapter, or in other chapters across the book.
+
+**_Example 2_**: Cross-referencing a section of a chapter.
+
+In the subchapter "Definitions" of the "Overview" chapter, we have created a label
+`rr-overview-definitions` for the section "Table of definitions for reproducibility".
+We can cross-reference it elsewhere in the book by using the following:
+
+```
+{ref}`rr-overview-definitions`
+```
+
+It will appear in your chapter like this: {ref}`rr-overview-definitions`.
+
+As before it doesn't matter where the label appears relative to the reference, this same syntax can be used whether you are cross-referencing sections within the same chapter, or in other chapters across the book.
 
 ### Providing an alternative title for the references
 


### PR DESCRIPTION
### Summary

Rationalises the examples of cross referencing in the `community-handbook/style/style-crossref section`.

Since the relative locations of the reference and citation don't affect the syntax, the three examples have been combined into a single example to help simplify the text.

Fixes #3349.

I also considered @kallewesterling's nice suggestion to add an example that includes a label, but noticed that it looks like this case is already covered in the section on the page ["Providing an alternative title for the references"](https://the-turing-way.netlify.app/community-handbook/style/style-crossref#providing-an-alternative-title-for-the-references), so I think there's no need to add this example. However another possibility might be to combine the section below into the examples.

### List of changes proposed in this PR (pull-request)

<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

* Combines the four examples provided into two, by avoiding the issue of where the label is relative to the citation.

### What should a reviewer concentrate their feedback on?

- [ ] Does the change make creating cross-references less clear?
- [ ] Does the updated text read okay?
- [ ] Does the page still render correctly?

### Acknowledging contributors

- [ ] All contributors to this pull request are already named in the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
