### PR TITLE
[ready for review] Manually update .all-contributorsrc

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -4325,7 +4325,8 @@
       "avatar_url": "https://avatars.githubusercontent.com/u/73224467?v=4",
       "profile": "https://susana465.github.io/",
       "contributions": [
-        "question"
+        "question",
+        "content"
       ]
     },
     {


### PR DESCRIPTION
Adding content contribution-type for Susana Roman Garcia, because the bot won't add it "again" (except it's not there)