### PR TITLE
[Ready for review] Corrected ToC link on config.yml

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -28,7 +28,7 @@ newPRWelcomeComment: >
 
   - Check for any abbreviations or latin phrases (such as "e.g." or "i.e.") in your writing. See our [style guide](https://github.com/the-turing-way/the-turing-way/blob/main/CONTRIBUTING.md#writing-style) for more information on this topic.
 
-  - Make sure you have added your new chapter to the [Table of Contents](https://github.com/the-turing-way/the-turing-way/blob/main/book/website/_data/toc.yml)
+  - Make sure you have added your new chapter to the [Table of Contents](https://github.com/the-turing-way/the-turing-way/blob/main/book/website/_toc.yml)
 
   <br>We have Continuous Integration tests that check the writing style and will help you track down any slip-ups :recycle:
   The Netlify bot will also comment with a preview of the book with your additions so you can see how it will look once it's merged! :tada:


### PR DESCRIPTION
<!--
Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
-->
### Summary

This fixes issue #3413 

### List of changes proposed in this PR (pull-request)

* Changed ToC link in https://github.com/the-turing-way/the-turing-way/blob/main/.github/config.yml (under newPRWelcomeComment) to https://github.com/the-turing-way/the-turing-way/blob/main/book/website/_toc.yml


### What should a reviewer concentrate their feedback on?

- [ ] Has the correct link been added?
- [ ] Everything looks ok?


### Acknowledging contributors

<!-- Please select the correct box -->

- [ ] All contributors to this pull request are already named in the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file.
- [x] The following people should be added to the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file: @f-rower