### PR TITLE
[WIP] Theory and Practice of Working Groups - Community Handbook

### DIFF
--- a/book/website/community-handbook/governance/working-groups.md
+++ b/book/website/community-handbook/governance/working-groups.md
@@ -1,0 +1,220 @@
+# Theory and Practice of Working Groups
+
+Within *The Turing Way*, working groups are smaller groups of people that work together on a focus topic, theme, or type of work. Many communities within the wider open source ecosystem have establised working groups (i.e. [Project Jupyter](https://jupyter.org/governance/standing_committees_and_working_groups.html), [Kubernetes](https://github.com/kubernetes/community/blob/master/governance.md), [Eclipse Foundation](https://www.eclipse.org/org/workinggroups/process.php#wg-member-roles), [Sustain OSS](https://sustainoss.org/working-groups/), amongst others), and working groups have been used as an organisational structure across many institutions and government bodies.
+
+Historically, roles in the *The Turing Way* working groups have been informal: after existing streams of work had been identified, participants in working groups have been encouraged to develop ways of working that align with their needs. However, in some cases this has lead to the [tyranny of structurelessness](https://www.jofreeman.com/joreen/tyranny.htm), where lack of structure has lead to uncertainty of roles and responsibilities, and ultimately, stagnation of some existing groups.
+
+We believe that everyone in *The Turing Way* community has expertise to share, and thereby anyone can join, and/or be a part of a working group. While there are a few more more requirements for community members to *create* a working group, this is primarily to ensure to there is sufficient support for their efforts, and to ensure that they are aligned with the aims of the project, and that there is enough critical mass to warrant a working group as opposed to another organisational structure.
+
+While joining a working group is **not** mandatory to join *The Turing Way* community (meaning, all are welcome to get involved in *The Turing Way* project without getting involved with a working group), joining a working group provides an opportunity to do focused tasks in a specific area. For informal groups that are interested in formalising their work, developing a working group offers an opportunity for groups to benefit from formalised support from the core staff delivery team (employees of the Alan Turing Institute that are deployed to work on and with *The Turing Way*), as well as formal recognition of their efforts within the community.
+
+Within *The Turing Way*, working groups have historically been established with the help of the Community Manager, as a means of (1) formalising already existing and ongoing work within the community and/or (2) enabling work that addresses observed and documented needs of the project and community. This was primarily the case in 2022 and 2023.
+
+However, this document and enclosed templates hopes to make it possible for interested members of the community to self-organise, incubate, maintain, and/or eventually close a working group. This document, as is the case with *The Turing Way* guides themselves aims to be a living document, updated as the community and its governance evolves. 
+
+## Guidelines
+
+All working groups, teams, and people within The Turing Way are responsible for adherring to The Turing Way [Code of Conduct](https://the-turing-way.netlify.app/community-handbook/coc) and our (upcoming) [Accessibility Policy](https://github.com/the-turing-way/the-turing-way/issues/3145), both in working group organisation and meeting facilitation.
+
+That is to say, every working group is responsible for establishing structures that that are:
+1. **Open & Transparent** for others to learn about, and join in on;
+2. **Inclusive** for all kinds of people and kinds of expertise;
+3. **Accessible** to join and participate in.
+
+Within a community that prioritises documentation, each working group has a responsibility to hold themselves accountable to document their ways of working and ongoing projects, as documented below in 'Roles & Responsibilities'.
+
+## Roles
+
+These roles suggested below are not meant to be permanent roles (i.e. a chair should not be a permanent appointee), but rather a guiding structure that working groups may build off of, expand, remix, and reuse for their own purposes. They are suggested not in order to create hierarchy within a working group, but in order to enable the smooth operation and maintenance of the collective team.
+
+At least 3 to 4 people are required to create a working group. These roles may be temporarily appointments, but one person may occupy multiple roles. However, one person should not chair multiple working groups, in order to enable diffusion of responsibilities as well as prevent over-extension of individuals within the community. People are allowed to join any number of working groups.
+
+- **Chair and co-chairs**: These person(s) are responsible for the creation and continuation of a working group. They play the role of the facilitator of the group, and are responsible for organising and chairing meetings, distributing responsibilities, and ensuring the broader accountability of the assembled group. While this role may be occupied by multiple people, it is important to establish how each person upholds the responsibilities of a chair in an equitable way.
+- **Secretary**: This person is responsible for ensuring the logistical reporting of the group. They are responsible for uploading meeting notes, ensuring that time-keeping is set in meetings, and that records of the group's activities are transparent, open, and accessible for others to access. For example, if the duties of the chair are distributed across multiple people, the secretary is responsible for documenting this format in the working group's repository.
+- **Leadership Council Liason**: Members of working groups have historically provided operational, strategic and advisory support for their area of work to *The Turing Way* leadership council (the collective group that includes the core delivery staff and (co-)leads of working groups). This has allowed them to inform project-related decisions and/or remain active in their specified area of work. In this iteration, an identified core team representative will participate in leadership council meetings, and represent the working group in wider governance meeting spaces. They will be responsible for relaying feedback, announcements, and discussions from the leadership council to the working group.
+    - Note: 
+- **Turing Staff Delivery Team Contact**: While working groups should be able to operate with autonomy in most decisions that apply to their work, sometimes they may require help from the TTW core staff delivery team in order to enable their operations, and/or support the incubation of the group. Each working group should have an assigned contact from the staff delivery team, most likely either the project Community Manager or Project Manager.
+- **Member**: Any Turing Way community member may join a working group without restriction, and without taking on a leadership role.
+
+## Responsibilities
+
+All working groups within the community have the responsibility to adhere to these three practices, as they relate to:
+1. **Reciprocity** within and towards the broader Turing Way community;
+2. **Open reporting** of practices and ways of working;
+3. **Transparent decision-making** within the working group; 
+
+### Reciprocity
+
+All working groups within the Turing Way have a responsibility to facilitate a reciprocal relationship with the wider community, as they represent a sustained engagement by community members on a topic or subject. 
+
+This engagement can take a variety of forms, and can look like:
+- Using TTW Community Calls like the Collaboration Cafe for working group meetings, discussions, and/or ongoing co-working
+- Hosting Fireside Chats and/or separate events (in consultation with and supported by the core staff delivery team) on topics related to the working group activities
+- Documenting related practices and/or topics in *The Turing Way* guides, either in the Community Handbook or other ongoing guides within the project
+- Creating a new guide related to the topics covered in the working group
+- Collaborating wtih existing working groups on projects related to infrastructure, accessibility, translation or other themes
+
+At minimum, all working groups are required to participate in and contribute to the The Turing Way Community Town Hall, a quarterly event that brings together core team delivery staff, advisory groups, and working group liasons. All community members are invited to attend these events.
+
+### Transparency
+
+All working group activities should be documented transparently so that non-working group members (and even non-Turing Way community members!) can learn about the working group's activities and projects. 
+
+This will help to address questions like:
+* How can more community members join in on working groups activities, or start their own?
+* How visible are various working group's activities for the rest of the community?
+* How can transparent reporting invite more people to participate in the conversation?
+
+## Decision-making
+
+In principle, primary decision-making should lie with the working group team itself. However, they may be different types of decisions that might require different people from across the project for consultation and support.
+
+This section details examples of decisions that may or may not require escalation for this aforementioned support. 
+
+Decisions they feel *empowered to take as an autonomous WG*
+* 
+* 
+* 
+* 
+
+Decisions that they invite *consultation and support* from the broader community
+* 
+* 
+* 
+* 
+
+Decisions that they invite *consultation and support* from the core staff delivery team
+* 
+* 
+* 
+* 
+
+Other decisions that don't fall under the above three categories?
+* 
+* 
+* 
+* 
+
+## Guidelines
+
+The following guidelines listed below have been created to help with the creation of working groups, from brainstorming to establishing structure.
+
+### Getting started
+
+While any community member can join a working group, setting up a working group has a few extra steps, in order to gage both need and interest in the development of the working group, alongside sharing more information with the broader community.
+
+A few guiding questions that may help with this process:
+* **Establish need**: What need does this working group fulfill for *The Turing Way* community?
+* **Establish requirements**: Does this topic or type of work require ongoing support, or can it be contained into another format? (i.e. should this be a working group, or can this task be accomplished in 4 Collaboration Cafes?)
+* **Establish membership**: Who would be a member of this working group currently (at time of founding)?
+
+### Establishing Purpose
+
+In order to create a working group, the purpose of the working group must be established. This may be done independently, and/or with the assistance of core delivery team staff and/or brainstorming with other community members and leaders. Establishing the purpose of a working group may take a series of brainstorming sessions and workshops, and there are a number of resources that may help with that self organising process. 
+
+*The Turing Way* Research Community Manager or Research Project Manager may also help with that process, in a series of facilitated sessions done at the Collaboration Cafe community call or in a separate set of discussions. Please reach out to them if you have any questions about the process, and/or would like some support in getting started. 
+
+A working group may focus on:
+1. A specific topic related to or of interest to *The Turing Way* community. (Examples of this may include: localisation, open source infrastructure maintenance, research infrastructure roles, research data management, etc.)
+2. A type of ongoing task or work currently being done within the project (i.e. training, mentoring, reviewing issues/pull requests)
+3. Anything else you would like to introduce to the community!
+
+### Establishing (Founding) Roles & Responsibilities
+
+While these roles and responsibilities may shift or evolve during the lifetime of a working group, having initial discussions that enable you to broach topics that will enable you to work together for the during of the working group.
+
+* **Discuss expectations**: Do all founding members have an understanding of the roles & responsibilities listed above to support a working group?
+* **Discuss founding membership roles**: How will this group distribute responsibilities in the roles listed above?
+* **Discuss working styles**: Has the group assembled for the working group collaborated previously? What working styles do people in this group prefer, and how does that affect the cadence, style and communication of the team?
+    * Note: Team-building and/or facilitation can be discussed with and/or assisted by the core staff delivery team. 
+* **Discuss previous experience with working groups or similar organizational formats**: What did you like about those formats, and what would you avoid? What kind of organisational histories do members of this working group come from?
+* **Discuss initial goals**: Are there concrete goals that your working group would like to accomplish at its founding? Have these goals been scoped appropriately based on resources, availability, and interest? 
+    * Note: Frameworks like SMART goals, Agile, Kanban, Scrum methodology may be valuable here.
+* **Discuss the group communication plans**: Are there communication tools you might need for your ongoing work (i.e. Slack channel, Github organisation, emails, etc)
+
+### Establishing a Working Group
+
+Once a working group has been established, it is important to identify and discuss the following topics within your group, as this will help to establish the candence and momentum of the group. 
+
+* **Establish regular meeting times and/or other group communication needs**: How often should the group meet? Would they like to use an existing community call (i.e. Collaboration Cafe) for real-time discussions, or develop a separate call for coworking?
+* **Establish a timeline for the working group**: How long should this group be operational? Should it be time-bound or shift indefinitely? 
+* **Establish roles timeline**: How long should people be appointed in their roles, and how often should these roles change?
+* **Create a github repository for organising working group activities**: All working group activities (including notes and the charter, mentioned below) should be archived in The Turing Way Github repository. [TEMPLATE LINKED HERE](https://github.com/the-turing-way/working-group-template)
+* **Establish a reporting mechanism and/or public notes archive**: How will you share-out meeting notes and group progress to the wider community? [TEMPLATE LINKED HERE](https://hackmd.io/@aleesteele/ttw-wg-notes-template) 
+    * Note: All working groups should upload notes to their respective github repository [in The Turing Way organisation](https://github.com/the-turing-way/the-turing-way/). 
+* **Establish appropriate permissions for accounts**: What accounts does this group need access to? Does this group have the proper account access & permissions in order to carry out your work?
+    * Note: The Community Manager and/or Project Manager can help with this! 
+* **Create a working group charter**: [TEMPLATE LINKED HERE](https://hackmd.io/@aleesteele/template-ttw-wg-charter)
+    * * Note: All working groups should upload this charter to their respective github repository [in The Turing Way organisation](https://github.com/the-turing-way/the-turing-way/).
+* **Create an open calendar invite**: This may require support of a core delivery staff member to add the information to the public google calendar
+* **Advertise on Community channels**:  Slack, Github, social media and/or the TTW newsletter to share the information about your working group
+    * Note: The Community Manager and/or Project Manager can help with this! Ask them on Slack or tag them on Github to share out this information, or co-create a communication plan.
+* **Create a slack channel for collaboration** (not required - but encouraged): Having an ongoing channel makes it easier to communicate across. What other communication channels might this group need?
+* **Add information about working group in Ways of Working and/or Governance documents**: Is there a public and up-to-date record of this working group?
+
+### Approving a Working Group
+
+The approval process for a working group requires a bit more involvement from the wider community and leadership council, as it is important to understand what resources might be available to supp, and/or if the working group's aims are appropriate for the community. 
+
+1. **Completed community charter**: All working groups need to fill out a proposed working group charter ([template here](https://hackmd.io/@aleesteele/template-ttw-wg-charter)) that should be presented to the TTW leadership council and broader community for discusssion and review
+2. **Open discussion and/or Q&A**: All Discuss your idea in community spaces: such as the TTW Slack workspace, Github discussions/issues, and/or Community Calls like the Collaboration Cafe.  
+3. **Leadership council approval**: This creation of this working group must be approved by *The Turing Way* leadership council at their regular organisating calls. These meetings happen every three months, which you can find out about [in this schedule](https://).
+
+### Maintaining a Working Group
+
+While initiating a working group, maintaining a working group's activities is integral for the group's success. 
+
+On a quarterly basis, a working group should revisit its structures and ways of working in order to establish that the group is adhering to its established purpose. The following questions can be guidelines for doing so. These questions have also been compiled into this [working group quarterly audit template]():
+
+* **Review purpose**: Is this working group still fulfilling its established purpose? 
+* **Review progress**: Has this working been able to make progress towards its stated goals? What adjustments may need to be made in order to support this kind of work?
+* **Review process**: Is the existing way of working valuable for this team currently? Are there other processes (decision-making, conflict manage)
+    * Note: The Community Manager and/or Project Manager can help with facilitating this! 
+* **Review roles**: Is everyone in the group in a role they would like to stay in? If not, how should these roles change?
+
+### Sunsetting a Working Group
+
+Deciding when to sunset a working group can be difficult. Often, working groups may continue on indefinitely, and while there are a variety of reasons for this, this may be because there are not means of recognising when a group's aims and/or goals have shifted, or if a group's work is no longer needed. Knowing when it might be time to sunset a working group or shift its aims or direction is an important
+
+Reasons for sunsetting a working group can be for the following
+* **Decreased capacity**: Are there no longer enough people to support this working group? If the number of peope able to sustain a working group decreases to below two, the possibility of shutting down the working group should be discussed.
+* **Disciplinary action**: If there have been any actions taken that may have broken *The Turing Way* code of conduct, the Staff Delivery Team and/or TTW way co-leads reserve the right to retire the working group.
+* **Decision from leadership council**: If the actions or projects realted to the working group are not seen to be relevant to *The Turing Way* project more broadly, it is possible for the leadership council to disban a working group through a voting process.
+
+Once a group has decided to close down its efforts, consider the following:
+* **Document reasons for closing down working group**: Documentation is important for continuous learnings - for future and current working groups, as well as the wider community and even ecosystem that The Turing Way feeds into!
+    * If you need help with this documentation process, check out this [template]()
+* **Change the meeting information**: Remember to cancel meeting invites, and archive existing notes in the github repository
+* **Change the documentation about the group**: Remember to change the information about the groups activity in all spaces where information has been documented
+
+----
+
+### Sources
+
+The following resources were used in drafting this documentation:
+
+* Gitlab: https://about.gitlab.com/company/team/structure/working-groups/
+* Carpentries: https://docs.carpentries.org/topic_folders/governance/executive-council.html#executive-council-s-standing-committees
+* Open Life Science: https://docs.google.com/document/d/1EUHvYv5wvZiJSK4yYDwwDHs9Ds6tCjqB3XezqCaetEI/edit# 
+* Project Jupyter Governance: https://jupyter.org/governance/standing_committees_and_working_groups.html 
+* HOTOSM: https://wiki.openstreetmap.org/wiki/Humanitarian_OSM_Team/Working_groups 
+* Kubernetes: https://github.com/kubernetes/community/blob/master/governance.md
+* Decidim: https://meta.decidim.org/assemblies/our-governance
+* Open Life Science: https://docs.google.com/document/d/1pD_P8oKLenyxCM39PZxu3X8a6hZQ4jZi-fA-xBB3DXQ/edit#heading=h.gjdgxs
+* Django: https://docs.djangoproject.com/en/dev/internals/organization/
+* Social.coop: https://wiki.social.coop/wiki/Governance
+* I don’t know much about it but the “loomio” system they use looks interesting
+* Brockwell Greenhouses: https://www.brockwellgreenhouses.org.uk/governance-at-bpcg/
+* data.coop (danish): https://data.coop/#
+* An anti-recommendation Becoming an Arch Linux Developer — invitation only, prove your worth, get noticed
+* Code for Science & Society <- their fiscal sponsorship model
+* HOT OpenStreetMap: https://wiki.openstreetmap.org/wiki/Humanitarian_OSM_Team/Working_groups/Governance
+* Wikipedia: https://foundation.wikimedia.org/wiki/Home
+* Pyladies: https://pyladies.com/blog/Announcing-the-Inaugural-PyLadies-Global-Council/inaugural-pyladies-council/
+* Wikipedia Education Working Group: https://en.wikipedia.org/wiki/Wikipedia:Education_Working_Group 
+* Eclipse: https://www.eclipse.org/org/workinggroups/process.php 
+* IEEE SA: https://standards.ieee.org/develop/mobilizing-working-group/governedwg/
+* https://www.w3.org/Guide/process/charter.html
+* https://www.loomio.coop/working_groups.html
+* https://www.w3.org/Guide/process/charter.html
+* https://metaarchive.org/wp-content/uploads/2021/06/ma_charter_2021.pdf


### PR DESCRIPTION
### Summary

This draft pull request brings together material that assists with the process of creating, maintaining, and sunsetting working groups. The title is very welcome to change! 

Fixes #3287 #2434 #2729 

### What should a reviewer concentrate their feedback on?
- Feedback will be invited from the Infrastructure, Translation and Localisation, Accessibility, and Book Dash Working Groups in order to fill out the 'decision-making' section.
- Guidelines and Responsibilities - is this something that the working groups agree on?
- Should this document be split into subsections?
- I have added this into a 'governance' subfolder in the community handbook - should it be elsewhere?

### Acknowledging contributors

- [ ] All contributors to this pull request are already named in the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
