### PR TITLE
Update newsletters.md

### DIFF
--- a/book/website/community-handbook/newsletters.md
+++ b/book/website/community-handbook/newsletters.md
@@ -4,16 +4,7 @@
 _The Turing Way_ team releases newsletters every month to share the latest updates with the community and beyond.
 These newsletters include event announcements, updates from the project, highlights from the community, useful resources for new and existing contributors, promotion of any ongoing efforts, impact stories of long-standing members and shout outs to relevant online activities.
 
-While we send our newsletters by email to our subscribed members, we simultaneously publish and archive them [online on TinyLetter](https://tinyletter.com/TuringWay/archive) so that anyone outside the community can also learn about the project.
-
-```{figure} ../figures/scriberia-newsletter.*
----
-height: 400px
-name: scriberia-newsletter
-alt: two people collecting information and pushing it through a device that produces a newsletter
----
-A newsletter illustration. Adapted from _The Turing Way_ project illustration by Scriberia. Used under a CC-BY 4.0 licence. DOI: [10.5281/zenodo.3332807](https://doi.org/10.5281/zenodo.3332807).
-```
+While we send our newsletters by email to our subscribed members, we simultaneously publish and archive them [online on Buttondown](https://buttondown.email/turingway/archive/) so that anyone outside the community can also learn about the project.
 
 The main motivations to draft these newsletters are the following:
 1. Reflect on the team's and community's project goals and any important milestones achieved in the last month
@@ -21,7 +12,7 @@ The main motivations to draft these newsletters are the following:
 3. Share information about any upcoming events and opportunities for our members
 4. Maintain ongoing connections with the subscribed members
 
-Currently, Malvika Sharan drafts these newsletters that are proofread and co-published with Kirstie Whitaker.
+Currently, Anne Lee Steel or Alexandra Araujo Alvarez draft the newsletters that are proofread and co-published with Malvika Sharan and Kirstie Whitaker.
 Newsletters published before September 2020 have been written by Patricia Herterich and Kirstie Whitaker.
 
 In this chapter, we share the process we have established in _The Turing Way_ for collecting news items, drafting the newsletter, documenting any additional updates shared by community members and publishing them through TinyLetter.

--- a/book/website/community-handbook/newsletters.md
+++ b/book/website/community-handbook/newsletters.md
@@ -2,17 +2,17 @@
 # _The Turing Way_ Monthly Newsletters
 
 _The Turing Way_ team releases newsletters every month to share the latest updates with the community and beyond.
-These newsletters include event announcements, updates from the project, highlights from the community, useful resources for new and existing contributors, promotion of any ongoing efforts, impact stories of long-standing members and shout outs to relevant online activities.
+These newsletters include event announcements, updates from the project, highlights from the community, useful resources for new and existing contributors, promotion of any ongoing efforts, impact stories of long-standing members and shoutouts to relevant online activities.
 
 While we send our newsletters by email to our subscribed members, we simultaneously publish and archive them [online on Buttondown](https://buttondown.email/turingway/archive/) so that anyone outside the community can also learn about the project.
 
-The main motivations to draft these newsletters are the following:
+The main purpose and motivations for publishing these newsletters are the following:
 1. Reflect on the team's and community's project goals and any important milestones achieved in the last month
 2. Highlight and celebrate ongoing work and notable efforts of the community members and document them
 3. Share information about any upcoming events and opportunities for our members
 4. Maintain ongoing connections with the subscribed members
 
-Currently, Anne Lee Steele or Alexandra Araujo Alvarez draft the newsletters that are proofread and co-published with Malvika Sharan and Kirstie Whitaker.
-Newsletters published before September 2020 have been written by Patricia Herterich and Kirstie Whitaker.
+Newsletters are drafted by *The Turing Way* Research Community Manager with contributions from the project team and the community.
+Currently, Anne Lee Steele and Alexandra Araujo Alvarez draft the newsletters that are proofread and co-published with Malvika Sharan and Kirstie Whitaker.
 
 In this chapter, we share the process we have established in _The Turing Way_ for collecting news items, drafting the newsletter, documenting any additional updates shared by community members and publishing them through TinyLetter.

--- a/book/website/community-handbook/newsletters.md
+++ b/book/website/community-handbook/newsletters.md
@@ -12,7 +12,7 @@ The main motivations to draft these newsletters are the following:
 3. Share information about any upcoming events and opportunities for our members
 4. Maintain ongoing connections with the subscribed members
 
-Currently, Anne Lee Steel or Alexandra Araujo Alvarez draft the newsletters that are proofread and co-published with Malvika Sharan and Kirstie Whitaker.
+Currently, Anne Lee Steele or Alexandra Araujo Alvarez draft the newsletters that are proofread and co-published with Malvika Sharan and Kirstie Whitaker.
 Newsletters published before September 2020 have been written by Patricia Herterich and Kirstie Whitaker.
 
 In this chapter, we share the process we have established in _The Turing Way_ for collecting news items, drafting the newsletter, documenting any additional updates shared by community members and publishing them through TinyLetter.


### PR DESCRIPTION
I have updated the Buttondown link to access our Newsletter archive and removed the image that contained Tinyletter's logo.
