### PR TITLE
[Ready for review] Add coworking notes from march 2024

### DIFF
--- a/governance/community-calls/20240304-coworking.md
+++ b/governance/community-calls/20240304-coworking.md
@@ -1,6 +1,6 @@
 # Notes 4 March 2024
 
-## Attendees (4 March 2024)
+## Attendees
 
 * Emma
 * Bastian
@@ -13,4 +13,6 @@
 
 ## Notes
 
-* No notes
+* 
+* 
+* 

--- a/governance/community-calls/20240311-coworking.md
+++ b/governance/community-calls/20240311-coworking.md
@@ -1,4 +1,4 @@
-## Notes 11 March 2024
+# Notes 11 March 2024
 
 ## Attendees
 
@@ -20,5 +20,5 @@
 ## Notes
 
 * Notes from main chat (catching up - comparing Kinshasa and the arctic!):
-    * Powaqqatsi: [https://www.youtube.com/watch?v=sNVTmWRcUbY](https://www.youtube.com/watch?v=sNVTmWRcUbY)
-    * Silence by Erving Kagge: [https://www.waterstones.com/book/silence/erling-kagge/9780241309889](https://www.waterstones.com/book/silence/erling-kagge/9780241309889)
+   * Powaqqatsi: [https://www.youtube.com/watch?v=sNVTmWRcUbY](https://www.youtube.com/watch?v=sNVTmWRcUbY)
+   * Silence by Erving Kagge: [https://www.waterstones.com/book/silence/erling-kagge/9780241309889](https://www.waterstones.com/book/silence/erling-kagge/9780241309889)

--- a/governance/community-calls/20240318-coworking.md
+++ b/governance/community-calls/20240318-coworking.md
@@ -1,0 +1,18 @@
+# Notes 18 March 2024
+
+## Attendees
+
+* Aida 
+* Ale
+* Malvika
+* Gabin
+
+## Topics/Rooms
+
+* Main room
+*  CZI EoI Localisation proposal
+   * The Turing Way Localisation WG and project team wrote a proposal after a CZI workshop. Proposal was not successful, but there is an interest from CZI and we will submit the EoI.
+* Innovation strategy - [https://the-turing-way.netlify.app/collaboration/research-infrastructure-roles/ram.html](https://the-turing-way.netlify.app/collaboration/research-infrastructure-roles/ram.html) - Re-onboarding on Innovation activity across Turing, specifically links between Innovation and TPS and discussing future ways of working.  
+* Silent work 
+* AIUK
+   * Could Open Prototyping as a toolkit for co-creation projects be of practical use in TW? We're experimenting with it at AI UK DCE workshop to design collaborative work in a cross-disciplinary project. 

--- a/governance/community-calls/20240325-coworking.md
+++ b/governance/community-calls/20240325-coworking.md
@@ -1,0 +1,26 @@
+# Notes 26 February 2024
+
+## Attendees
+
+* Anne
+* Kirstie
+* Batool 
+* Aida 
+* Malvika
+
+## Apologies
+
+* Gabin: Traveling from Birmingham
+
+## Topics/Rooms
+
+* Main room
+* ECR event room (Batool \& Emma)
+* Accessibility Policy writing
+* Curricula Design (TEA and TTW) 
+*  RIR Personas Review
+
+## Notes
+
+* Main room - community calls
+   * [https://github.com/the-turing-way/the-turing-way/issues/3579](https://github.com/the-turing-way/the-turing-way/issues/3579)


### PR DESCRIPTION
### Summary

Archiving coworking call notes for:
- 26 February
- 4 March
- 11 March
- 18 March
- 25 March