### PR TITLE
Updating references of Eventbrite to Zoom for event organisation! 

### DIFF
--- a/.github/ISSUE_TEMPLATE/BOOK_DASH_CHECKLIST.md
+++ b/.github/ISSUE_TEMPLATE/BOOK_DASH_CHECKLIST.md
@@ -21,7 +21,7 @@ We have created the following checklists, which are chronologically structured t
 
 ## Before the Event -- all online
 
-- [ ] Finalise dates based on the location and core team’s availability
+- [ ] Finalise dates based on the location and core team's availability
 - [ ] Set up a form (see a template [here](https://the-turing-way.netlify.app/community-handbook/bookdash/bookdash-selection.html#ch-bookdash-application-additional-materials)) for application by updating the previous version of the form
 - [ ] Write a short description for online advertisement
 - [ ] Open a call for application as well as invite interest to join the committee
@@ -32,9 +32,9 @@ We have created the following checklists, which are chronologically structured t
 - [ ] Set up an online platform ([Zoom](https://zoom.us/), or other accessible software) for remote collaboration
 - [ ] Copy the HackMD index page for the event using last round for reference: https://hackmd.io/@turingway/bookdash-nov2022-index
 - [ ] Update shared HackMD for pre-event calls<ch-template-bookdash-precall>, [book dash event](https://the-turing-way.netlify.app/community-handbook/templates/template-bookdash-notes.html#ch-template-bookdash-notes) and [feedback](https://the-turing-way.netlify.app/community-handbook/templates/template-bookdash-feedback.html#ch-template-bookdash-feedback)
-- [ ] Copy the Eventbrite page from last round for the Book Dash attendees - set a registration code 
+- [ ] Copy the [Zoom instructions](HOWTOZOOM.md) for the Book Dash attendees
 - [ ] Send a reminder in next newsletters with more details if needed
-- [ ] Copy the share out Eventbrite page (2 sessions)
+- [ ] Copy the share out [Zoom instructions](HOWTOZOOM.md) (2 sessions)
 - [ ] Clearly state the following information in an application form and later communicate by email with the selected participants:
   -   what financial support will be available for either online or in-person events 
   -  What arrangements will be available online (such as online helpers and designated mentors) or on-site (such as quiet room and child care) for in-person events 
@@ -56,15 +56,15 @@ We have created the following checklists, which are chronologically structured t
   - Use this meeting to also allocate tasks for during and after the event (indicate that on the GitHub issues)
 
 **After the selection phase**
-- [ ] Send an email to the selected attendees with Eventbrite page and registration code
-- [ ] Send an email to the unselected attendees with feedback
+- [ ] Email the selected attendees with [Zoom instructions](HOWTOZOOM.md)
+- [ ] Email the unselected attendees with feedback
 - [ ] Set up an email chain and a Slack channel to connect all members and share updates
 - [ ] Provide details on Code of Conduct, contribution guideline and ways to get involved in an ongoing discussion
 - [ ] Update presentation for introducing the project to the participants on day-1 of the Book Dash
 - [ ] Host the onboarding call one week before the event to share logistics and facilitate the drafting of SMART goals
 - [ ] Group participants into the proposed working groups as per their SMART goals from the onboarding call
 - [ ] Host the onboarding call one week before the event to share logistics and facilitate the drafting of SMART goals
-- [ ] Send a reminder email to register on Eventbrite sharing important links and information including support grant, GitHub session, onboarding call info and reimbursement process
+- [ ] Send a reminder email with important links and information including support grant, GitHub session, onboarding call info and reimbursement process
 - [ ] Create a GitHub issue to collect bio and highlight of the participants to add them to the Contributors Record
 
 ### Additional task for an online event
@@ -81,10 +81,10 @@ We have created the following checklists, which are chronologically structured t
 
 ### Additional task for an in-person Event - Local HUBS
 - [ ] Book location for in-person events
-- [ ] Collate participants’ preference for travel, meal, accommodation, and accessibility request through the registration form
-- [ ] Send an email to the participants regarding their travel, accommodation, schedule, and meal
+- [ ] Collate participants' preference for travel, meal, accommodation, and accessibility request through the registration form
+- [ ] Email the participants regarding their travel, accommodation, schedule, and meal
 - [ ] Book catering for lunch and coffee breaks
-- [ ] Double-check with each participant if their plan as given on their registration hasn’t changed
+- [ ] Double-check with each participant if their plan as given on their registration hasn't changed
 
 **When funding for travel and accommodation is available**
 - [ ] Book hotels rooms for people who requested accommodation

--- a/HOWTOZOOM.md
+++ b/HOWTOZOOM.md
@@ -1,0 +1,30 @@
+### Checklist for using Zoom platform
+
+### Before event
+- [ ] Create event at set time
+- [ ] Add co-hosts to call (Note: co-hosts cannot edit settings and/or register if they are made co-hosts)
+- [ ] (If applicable): Double-check with co-hosts that they have accepted the invitation to co-host, as they cannot register for the event
+- [ ] (If applicable): Add in description for event (Note: for data protection, we need to add the statement: "Data collected through this form is subject to the Alan Turing Institute's privacy policy. Learn more here: https://www.turing.ac.uk/privacy-policy".
+- [ ] (If applicable): Check 'Registration form' option
+- [ ] (If applicable): Check 'Close registration after meeting date' if applicable
+- [ ] (If applicable): Upload banner (check if banner is right size and resolution)
+- [ ] (If applicable): Manually add additional questions to sign-up form (we usually add: "What are you most interested in learning about during this call?"
+- [ ] (If applicable): Manually move sign-up information to 3rd party storage platform for archiving (no option to export to csv file)
+- [ ] (If applicable): Customise email for registrations (Note: the option here is to add a line of text – not a custom message). 
+- [ ] (If applicable): Manually send automatically-generated reminder email from Zoom platform
+- [ ] (If applicable): Use manually-exported list of registrations to send a reminder/invitation email to registrants before the event (if wanting to use a custom email - not template from Zoom)
+
+### During event
+- [ ] Make people/trainers/etc co-hosts of call (will have to manually do so if co-hosts have not accepted invitation to host call, and/or registered as attendees and not as hosts)
+- [ ] Turn on transcriptions (used for subtitles)
+- [ ] (If applicable) Ask for consent and share information about recording 
+
+### After event
+**Note: sometimes video and/or zoom events are deleted, so it's important to archive quickly.**
+- [ ] Download video and subtitles
+- [ ] Upload to Youtube or other
+   - [ ] Add chapter markers
+   - [ ] Add designed thumbnail
+   - [ ] Add in event information to description
+   - [ ] Correct transcriptions/subtitles
+


### PR DESCRIPTION
### Summary

Fixes #3594


This pull request updates the references to Eventbrite with information on setting up Zoom based event management

### List of changes proposed in this PR (pull-request)

- Updates Eventbrite references 
- `HOWTOZOOM.md` will be added in the root of the repo to provide Zoom instructions
    - This needs a better name and to be put somewhere better, I didn't know where! 
    - @aleesteele @malvikasharan would you have an idea of where to put this file as Im going to be linking to it from a few other files. It's currently the text on zoom from the issue 
    - [HOWTOZOOM.md](https://github.com/the-turing-way/the-turing-way/compare/eventbrite-%3Ezoom?expand=1#diff-0e6e212bac2158e5bce346484192f3005216be179cc961bdcff5da2bbbe68fa8)

### What should a reviewer concentrate their feedback on?

- [ ] Does the change make sense and improve the clarity for setting up Zoom events


### Acknowledging contributors

- [ ] All contributors to this pull request are already named in the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file.

- [ ] The following people should be added to the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->