### PR TITLE
actually distinguish between licence and license

### DIFF
--- a/book/website/reproducible-research/licensing.md
+++ b/book/website/reproducible-research/licensing.md
@@ -19,7 +19,7 @@ No previous knowledge is needed, this chapter explains how important it is to un
 ## Summary
 
 > This chapter was written using American English, in which the word **license** is a noun **_and_** a verb.
-> With British English, however, **license** is a noun (as in, _to issue a license_), while **license** is a verb (as in, _they licensed the event_).
+> With British English, however, **licence** is a noun (as in, _to issue a licence_), while **license** is a verb (as in, _they licensed the event_).
 
 'Intellectual Property (IP)' law is a complex subject.
 However some understanding of it is important for anyone producing creative works governed by it including software, datasets, graphics and more.


### PR DESCRIPTION
### Summary

The Licensing section made a point of distinguishing between American and British English, but for British English, both noun and verb were still spelled as `license`.

### List of changes proposed in this PR (pull-request)

- Replace `license` with `licence` when referring to the noun in British English

### Acknowledging contributors

- [ ] All contributors to this pull request are already named in the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file.
- [x] The following people should be added to the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file: @sjvrijn 
