### PR TITLE
Homepage: avoid qualifying The Turing Way as open source

### DIFF
--- a/book/website/index.md
+++ b/book/website/index.md
@@ -3,7 +3,7 @@
 
 *Welcome to The Turing Way handbook to reproducible, ethical and collaborative data science.*
 
-_The Turing Way_ project is open source, open collaboration, and community-driven.
+_The Turing Way_ project is providing its source files, open collaboration, and community-driven.
 We involve and support a diverse community of contributors to make data science accessible, comprehensible and effective for everyone.
 Our goal is to provide all the information that researchers and data scientists in academia, industry and the public sector need to ensure that the projects they work on are easy to reproduce and reuse.
 

--- a/book/website/index.md
+++ b/book/website/index.md
@@ -3,7 +3,7 @@
 
 *Welcome to The Turing Way handbook to reproducible, ethical and collaborative data science.*
 
-_The Turing Way_ project is providing its source files, open collaboration, and community-driven.
+_The Turing Way_ is an open science, open collaboration, and community-driven project.
 We involve and support a diverse community of contributors to make data science accessible, comprehensible and effective for everyone.
 Our goal is to provide all the information that researchers and data scientists in academia, industry and the public sector need to ensure that the projects they work on are easy to reproduce and reuse.
 

--- a/book/website/reproducible-research/open/open-source.md
+++ b/book/website/reproducible-research/open/open-source.md
@@ -4,7 +4,7 @@
 (rr-open-source-whatis)=
 ## What Is Open Source Software?
 
-When a project is open-source [{term}`def<Open Source Software>`], anybody can view, use, modify, and distribute the project for any purpose.
+When a software is open-source [{term}`def<Open Source Software>`], anybody can view, use, modify, and distribute its source code for any purpose.
 These permissions are enforced through an open-source licence.
 Open source is powerful because it lowers the barriers to adoption, allowing ideas to spread quickly.
 In its most basic form, open-sourcing your software means putting your code online where it can be viewed and reused by others.


### PR DESCRIPTION
Alternative proposal for #3705 if the concept of « open source » is assumed strictly related to software.

Context for origin of the proposal: https://github.com/the-turing-way/the-turing-way/pull/3705#issuecomment-2161237778

Problematic situation where « open source » is explained and usually assumed in relation to software, but used to qualify the Turing Way handbook in an unclear manner as it is a non-software artefact. This fuels confusion about the concept.

This is coming next to debates on the meaning of open source beyond software, which may be applied to digital resources whose sources are provided. Questioning regarding the fact open source should be used only for software, PR for this case.

Need of an appropriate use of the terminology through the resource and provide explanation that would reflect this understanding.