### PR TITLE
Add references to the bibliography and a cross reference in open source software

### DIFF
--- a/book/website/_bibliography/references.bib
+++ b/book/website/_bibliography/references.bib
@@ -2691,7 +2691,6 @@ numpages = {10}
   doi = {10.48550/ARXIV.1201.0490},
   url = {https://arxiv.org/abs/1201.0490},
   version = {4},
-  keywords = {FOS: Computer and information sciences,Machine Learning (cs.LG),Mathematical Software (cs.MS)}
 }
 
 

--- a/book/website/_bibliography/references.bib
+++ b/book/website/_bibliography/references.bib
@@ -2669,7 +2669,7 @@ numpages = {10}
  and Hanke, Michael and Keator, David and Li, Xiangrui and Michael, Zachary and Maumet, Camille and Nichols, B. Nolan and Nichols, Thomas E. and Pellman, John and Poline, Jean-Baptiste and Rokem, Ariel and Schaefer, Gunnar and Sochat, Vanessa and Triplett
 , William and Turner, Jessica A. and Varoquaux, Gaël and Poldrack, Russell A.},
   date = {2016-06-21},
-  journaltitle = {Scientific Data},
+  journal = {Scientific Data},
   shortjournal = {Sci Data},
   volume = {3},
   number = {1},
@@ -2688,6 +2688,7 @@ numpages = {10}
   author = {Pedregosa, Fabian and Varoquaux, Gaël and Gramfort, Alexandre and Michel, Vincent and Thirion, Bertrand and Grisel, Olivier and Blondel, Mathieu and Müller, Andreas and Nothman, Joel and Louppe, Gilles and Prettenhofer, Peter and Weiss, Ron and Dubourg, Vincent and Vanderplas, Jake and Passos, Alexandre and Cournapeau, David and Brucher, Matthieu and Perrot, Matthieu and Duchesnay, Édouard},
   date = {2012},
   publisher = {arXiv},
+  journal = {arXiv},
   doi = {10.48550/ARXIV.1201.0490},
   url = {https://arxiv.org/abs/1201.0490},
   urldate = {2024-06-21},

--- a/book/website/_bibliography/references.bib
+++ b/book/website/_bibliography/references.bib
@@ -2690,8 +2690,6 @@ numpages = {10}
   journal = {arXiv},
   doi = {10.48550/ARXIV.1201.0490},
   url = {https://arxiv.org/abs/1201.0490},
-  urldate = {2024-06-21},
-  abstract = {Scikit-learn is a Python module integrating a wide range of state-of-the-art machine learning algorithms for medium-scale supervised and unsupervised problems. This package focuses on bringing machine learning to non-specialists using a general-purpose high-level language. Emphasis is put on ease of use, performance, documentation, and API consistency. It has minimal dependencies and is distributed under the simplified BSD license, encouraging its use in both academic and commercial settings. Source code, binaries, and documentation can be downloaded from http://scikit-learn.org.},
   version = {4},
   keywords = {FOS: Computer and information sciences,Machine Learning (cs.LG),Mathematical Software (cs.MS)}
 }

--- a/book/website/_bibliography/references.bib
+++ b/book/website/_bibliography/references.bib
@@ -2662,3 +2662,38 @@ numpages = {10}
 	note = {[Online; accessed 7. Jun. 2024]},
 	url = {https://www.weforum.org/agenda/2022/05/digital-public-goods-open-source-technology-ecosystem}
 }
+
+@article{gorgolewski2016NIPY,
+  title = {The Brain Imaging Data Structure, a Format for Organizing and Describing Outputs of Neuroimaging Experiments},
+  author = {Gorgolewski, Krzysztof J. and Auer, Tibor and Calhoun, Vince D. and Craddock, R. Cameron and Das, Samir and Duff, Eugene P. and Flandin, Guillaume and Ghosh, Satrajit S. and Glatard, Tristan and Halchenko, Yaroslav O. and Handwerker, Daniel A.
+ and Hanke, Michael and Keator, David and Li, Xiangrui and Michael, Zachary and Maumet, Camille and Nichols, B. Nolan and Nichols, Thomas E. and Pellman, John and Poline, Jean-Baptiste and Rokem, Ariel and Schaefer, Gunnar and Sochat, Vanessa and Triplett
+, William and Turner, Jessica A. and Varoquaux, Gaël and Poldrack, Russell A.},
+  date = {2016-06-21},
+  journaltitle = {Scientific Data},
+  shortjournal = {Sci Data},
+  volume = {3},
+  number = {1},
+  pages = {160044},
+  issn = {2052-4463},
+  doi = {10.1038/sdata.2016.44},
+  url = {https://www.nature.com/articles/sdata201644},
+  urldate = {2024-06-21},
+  abstract = {Abstract             The development of magnetic resonance imaging (MRI) techniques has defined modern neuroimaging. Since its inception, tens of thousands of studies using techniques such as functional MRI and diffusion weighted imaging have allowed for the non-invasive study of the brain. Despite the fact that MRI is routinely used to obtain data for neuroscience research, there has been no widely adopted standard for organizing and describing the data collected in an imaging experiment. This renders sharing and reusing data (within or between labs) difficult if not impossible and unnecessarily complicates the application of automatic pipelines and quality assurance protocols. To solve this problem, we have developed the Brain Imaging Data Structure (BIDS), a standard for organizing and describing MRI datasets. The BIDS standard uses file formats compatible with existing software, unifies the majority of practices already common in the field, and captures the metadata necessary for most common data processing operations.},
+  langid = {english}
+}
+
+@article{pedregosa2012ScikitLearn,
+  title = {Scikit-Learn: {{Machine Learning}} in {{Python}}},
+  shorttitle = {Scikit-Learn},
+  author = {Pedregosa, Fabian and Varoquaux, Gaël and Gramfort, Alexandre and Michel, Vincent and Thirion, Bertrand and Grisel, Olivier and Blondel, Mathieu and Müller, Andreas and Nothman, Joel and Louppe, Gilles and Prettenhofer, Peter and Weiss, Ron and Dubourg, Vincent and Vanderplas, Jake and Passos, Alexandre and Cournapeau, David and Brucher, Matthieu and Perrot, Matthieu and Duchesnay, Édouard},
+  date = {2012},
+  publisher = {arXiv},
+  doi = {10.48550/ARXIV.1201.0490},
+  url = {https://arxiv.org/abs/1201.0490},
+  urldate = {2024-06-21},
+  abstract = {Scikit-learn is a Python module integrating a wide range of state-of-the-art machine learning algorithms for medium-scale supervised and unsupervised problems. This package focuses on bringing machine learning to non-specialists using a general-purpose high-level language. Emphasis is put on ease of use, performance, documentation, and API consistency. It has minimal dependencies and is distributed under the simplified BSD license, encouraging its use in both academic and commercial settings. Source code, binaries, and documentation can be downloaded from http://scikit-learn.org.},
+  version = {4},
+  keywords = {FOS: Computer and information sciences,Machine Learning (cs.LG),Mathematical Software (cs.MS)}
+}
+
+

--- a/book/website/_bibliography/references.bib
+++ b/book/website/_bibliography/references.bib
@@ -2669,6 +2669,7 @@ numpages = {10}
  and Hanke, Michael and Keator, David and Li, Xiangrui and Michael, Zachary and Maumet, Camille and Nichols, B. Nolan and Nichols, Thomas E. and Pellman, John and Poline, Jean-Baptiste and Rokem, Ariel and Schaefer, Gunnar and Sochat, Vanessa and Triplett
 , William and Turner, Jessica A. and Varoquaux, Gaël and Poldrack, Russell A.},
   date = {2016-06-21},
+  year = {2016},
   journal = {Scientific Data},
   shortjournal = {Sci Data},
   volume = {3},
@@ -2687,6 +2688,7 @@ numpages = {10}
   shorttitle = {Scikit-Learn},
   author = {Pedregosa, Fabian and Varoquaux, Gaël and Gramfort, Alexandre and Michel, Vincent and Thirion, Bertrand and Grisel, Olivier and Blondel, Mathieu and Müller, Andreas and Nothman, Joel and Louppe, Gilles and Prettenhofer, Peter and Weiss, Ron and Dubourg, Vincent and Vanderplas, Jake and Passos, Alexandre and Cournapeau, David and Brucher, Matthieu and Perrot, Matthieu and Duchesnay, Édouard},
   date = {2012},
+  year = {2012},
   publisher = {arXiv},
   journal = {arXiv},
   doi = {10.48550/ARXIV.1201.0490},

--- a/book/website/_bibliography/references.bib
+++ b/book/website/_bibliography/references.bib
@@ -2678,9 +2678,6 @@ numpages = {10}
   issn = {2052-4463},
   doi = {10.1038/sdata.2016.44},
   url = {https://www.nature.com/articles/sdata201644},
-  urldate = {2024-06-21},
-  abstract = {Abstract             The development of magnetic resonance imaging (MRI) techniques has defined modern neuroimaging. Since its inception, tens of thousands of studies using techniques such as functional MRI and diffusion weighted imaging have allowed for the non-invasive study of the brain. Despite the fact that MRI is routinely used to obtain data for neuroscience research, there has been no widely adopted standard for organizing and describing the data collected in an imaging experiment. This renders sharing and reusing data (within or between labs) difficult if not impossible and unnecessarily complicates the application of automatic pipelines and quality assurance protocols. To solve this problem, we have developed the Brain Imaging Data Structure (BIDS), a standard for organizing and describing MRI datasets. The BIDS standard uses file formats compatible with existing software, unifies the majority of practices already common in the field, and captures the metadata necessary for most common data processing operations.},
-  langid = {english}
 }
 
 @article{pedregosa2012ScikitLearn,

--- a/book/website/reproducible-research/open/open-source.md
+++ b/book/website/reproducible-research/open/open-source.md
@@ -5,7 +5,7 @@
 ## What Is Open Source Software?
 
 When a software is open-source [{term}`def<Open Source Software>`], anybody can view, use, modify, and distribute its source code for any purpose.
-These permissions are enforced through an open-source licence.
+These permissions are enforced through an {ref}`open-source licence<rr-licensing>`.
 Open source is powerful because it lowers the barriers to adoption, allowing ideas to spread quickly.
 In its most basic form, open-sourcing your software means putting your code online where it can be viewed and reused by others.
 

--- a/book/website/reproducible-research/open/open-source.md
+++ b/book/website/reproducible-research/open/open-source.md
@@ -10,10 +10,10 @@ Open source is powerful because it lowers the barriers to adoption, allowing ide
 In its most basic form, open-sourcing your software means putting your code online where it can be viewed and reused by others.
 
 Many of the most widely used research software is open source.
-Perhaps the paradigmatic example is the scikit-learn Python package for machine learning (Pedregosa et al., 2011), which, in the space of just over five years, has attracted over 500 unique contributors, 20,000 individual code contributions, and 2,500 article citations.
+Perhaps the paradigmatic example is the scikit-learn Python package for machine learning {cite:ps}`pedregosa2012ScikitLearn`, which, in the space of just over five years, has attracted over 500 unique contributors, 20,000 individual code contributions, and 2,500 article citations.
 Producing a comparable package using a traditional closed-source approach would likely not be feasible.
 It would, at the very least, require a budget of tens of millions of dollars.
-While scikit-learn is an outlier, hundreds of other open-source packages that support much more domain-specific needs depend similarly on unsolicited community contributions; for example, the NIPY (neuroimaging in Python) group of projects in neuroimaging (Gorgolewski et al., 2016).
+While scikit-learn is an outlier, hundreds of other open-source packages that support much more domain-specific needs depend similarly on unsolicited community contributions; for example, the NIPY (neuroimaging in Python) group of projects in neuroimaging {cite:ps}`gorgolewski2016NIPY`).
 Notably, such contributions not only result in new functionality from which the broader community can benefit, but also regularly provide their respective authors with greater community recognition, and lead to new project and employment opportunities.
 
 Researchers that make use of open-source software often make changes to them, such as adding features they need for their research, or fixing bugs.


### PR DESCRIPTION
### Summary

Add 2 references mentioned in the text but not present in the bibliography to the bibliography, and add a cross reference to open source licensing chapter where it was mentioned here.

Addresses some points raised in #3705 

### List of changes proposed in this PR (pull-request)

* cross reference licensing chapter on first mention of 'open-source licence'
* Add reference to Gorgolewski et al 2016 to the bibliography
* Add reference to Pedregosa et al. 2012 to the bibliography

### What should a reviewer concentrate their feedback on?

- [ ] Everything looks ok?

### Acknowledging contributors

<!-- Please select the correct box -->

- [x] All contributors to this pull request are already named in the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file.
