### PR TITLE
Adding governance-maintainers image

### DIFF
--- a/book/website/collaboration/maintain-review.md
+++ b/book/website/collaboration/maintain-review.md
@@ -12,6 +12,15 @@ For any open source project, one of the most challenging tasks for a new contrib
 Contribution guidelines of open source projects outline how community members can make such a contribution, but they often do not explain how one can contribute to the project by becoming a project maintainer.
 Dedicated project maintainers from the project's core team or volunteer community often take up the role of supporting such contributions by other contributors.
 
+```{figure} ../figures/governance-maintainers-without-text-only.*
+---
+height: 500px
+name: governance-maintainers
+alt: Scriberia illustration showing the role of maintainers in open source projects. A tree represents the project, and the people taking care of the three are the maintainers. 
+---
+_The Turing Way_ project illustration by Scriberia. Used under a CC-BY 4.0 licence. DOI: [10.5281/zenodo.3332807](https://doi.org/10.5281/zenodo.3332807).
+``` 
+
 This subchapter sheds light on the role and tasks of such project maintainers who manage or coordinate community discussions, mentor contributions, support resource development, help in issue triaging, and review Pull Requests or PRs on an online collaborative GitHub project.
 It also provides the best practices to be used while contributing to a project as a maintainer.
 


### PR DESCRIPTION
### Summary
Adding governance-maintainers image to the collaboration sub-chapter.

### List of changes proposed in this PR (pull-request)

<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
- [x] Added code and link for figure
- [x] Added alt text
- [ ] Reviewed image to check all looks ok using netlify preview

### What should a reviewer concentrate their feedback on?
- [ ] Everything looks ok?

### Acknowledging contributors

<!-- Please select the correct box -->

- [ ] All contributors to this pull request are already named in the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
