### PR TITLE
Fix incorrect link in cite.md

### DIFF
--- a/book/website/foreword/cite.md
+++ b/book/website/foreword/cite.md
@@ -3,7 +3,7 @@
 
 All material in _The Turing Way_ is available under a [CC-BY 4.0 licence](https://github.com/the-turing-way/the-turing-way/blob/master/LICENSE.md).
 
-You can cite _The Turing Way_ through the project's Zenodo archive using DOI: [10.5281/zenodo.3233853](https://zenodo.org/doi/10.5281/zenodo.3332807).
+You can cite _The Turing Way_ through the project's Zenodo archive using DOI: [10.5281/zenodo.3233853](https://zenodo.org/doi/10.5281/zenodo.3233853).
 
 The citation will look something like:
 


### PR DESCRIPTION
### Summary

One of the links to the Zenodo repository for the book incorrectly had the repository for the illustrations as its target (despite the link text being the correct DOI).

### List of changes proposed in this PR (pull-request)

* Fix one mistargeted link in cite.md

### What should a reviewer concentrate their feedback on?

- [ ] Everything looks ok?


### Acknowledging contributors

- [ ] The following people should be added to the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file: @edbennett - but only if "fixing one typo" is sufficient to be considered a contributor!