### PR TITLE
Update afterword.md to correct typo

### DIFF
--- a/book/website/afterword/afterword.md
+++ b/book/website/afterword/afterword.md
@@ -10,7 +10,7 @@ The community collaboration and development aspects of the book has been written
 ---
 height: 400px
 name: road-to-reproducibility
-alt: Three hands holding magnifying glasses and varifying 'road to reproducibility' of The Turig Way.
+alt: Three hands holding magnifying glasses and varifying 'road to reproducibility' of The Turing Way.
 ---
 Road to Reproducibility. _The Turing Way_ project illustration by Scriberia. Used under a CC-BY 4.0 licence. DOI: [10.5281/zenodo.3332807](https://doi.org/10.5281/zenodo.3332807).
 ```


### PR DESCRIPTION
[BUGFIX] mentioned in [#3110](https://github.com/the-turing-way/the-turing-way/issues/3110)

@ciupava described the typo in the issue linked above in the alt text section of `afterword.md` of the book website.

### Summary

I have fixed the typo

Fixes #<3110>

*Lorem ipsum dolor sit amet, consectetur adipiscing.*

### List of changes proposed in this PR (pull-request)


* Turig -> Turing


### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

- [ ] *Check if typo is fixed.*
- [ ] Everything looks ok?


### Acknowledging contributors


- [ ] The following people should be added to the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file: @nghuixin @ciupava 
