### PR TITLE
Remove banner

### DIFF
--- a/book/website/_config.yml
+++ b/book/website/_config.yml
@@ -22,7 +22,6 @@ execute:
 #######################################################################################
 # HTML-specific settings
 html:
-  announcement              : "⚠️<i>The Turing Way</i> is moving domain! We will soon move to <a href='https://book.the-turing-way.org'>book.the-turing-way.org</a>. You can use new domain now! Later, the old domain will redirect you to the new location."
   favicon                   : "./figures/logo/favicon-32x32.png"  # A path to a favicon image
   navbar_number_sections    : False  # Add a number to each section in your left navbar
   google_analytics_id       : "UA-167881009-1"  # A GA id that can be used to track book views.


### PR DESCRIPTION
### Summary

It's been ~7 months since we switched domains and added a banner.
I think it has served its purpose and it might be time (now or soon) to remove it.
This PR removes the banner which was introduced here: https://github.com/the-turing-way/the-turing-way/pull/3537

