### PR TITLE
fix typos in alt text

### DIFF
--- a/book/website/reproducible-research/rdm/rdm-metadata.md
+++ b/book/website/reproducible-research/rdm/rdm-metadata.md
@@ -18,7 +18,7 @@ Documentation allows data users have sufficient information to understand the so
 ```{figure} ../../figures/documentation.*
 ---
 name: documentation
-alt: The figure goes through a dark wood setting lights alongthe way. The lights are blocks of text - one can see that these are pieces of documentation. They make it easy for collegues to find their way. In the darkness one sees another figure - someon got lost in the woods where no documentation was available.
+alt: The figure goes through a dark wood setting lights along the way. The lights are blocks of text - one can see that these are pieces of documentation. They make it easy for collegues to find their way. In the darkness one sees another figure - someone got lost in the woods where no documentation was available.
 ---
 Illustration about peer review.
 _The Turing Way_ project illustration by Scriberia. Used under a CC-BY 4.0 licence. DOI: 10.5281/zenodo.3332807.

--- a/book/website/reproducible-research/rdm/rdm-storage.md
+++ b/book/website/reproducible-research/rdm/rdm-storage.md
@@ -40,7 +40,7 @@ An open source project created a quite complete one at https://github.com/tonic-
 ```{figure}  ../../figures/file-management-manual.jpg
 ---
 name: Folder structure for research data
-alt: A protagonist has a file written "readme" on it and bring it to another protagonist who stays in front of a file drawer system. There are  three drawers labelled "data", "code", and "results".
+alt: A protagonist has a file with "readme" written on it and brings it to another person standing in front of a filing cabinet. The cabinet has three drawers labelled "data", "code", and "results".
 ---
 _The Turing Way_ project illustration by Scriberia. Used under a CC-BY 4.0 licence. DOI: [10.5281/zenodo.3332807](https://doi.org/10.5281/zenodo.3332807).
 ```


### PR DESCRIPTION
## Summary

Fixed the typos in two figure's alt text. 

Addresses (but does not close) #3882

### List of changes proposed in this PR (pull-request)

* Alt text for documentation figure
* Alt text for data structure for research data figure


### What should a reviewer concentrate their feedback on?


- [ ] Everything looks ok?


### Acknowledging contributors



- [x] All contributors to this pull request are already named in the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
