### PR TITLE
Create accessibility-policy.md in community handbook - add rendered link

### DIFF
--- a/book/website/_toc.yml
+++ b/book/website/_toc.yml
@@ -809,6 +809,8 @@ chapters:
             file: community-handbook/coc/coc-enforcement
           - title: Acknowledgements
             file: community-handbook/coc/coc-acknowledgement
+      - title: Accessibility Policy
+        file: community-handbook/accessibility-policy
       - title: Style Guide
         file: community-handbook/style
         sections:

--- a/book/website/community-handbook/accessibility-policy.md
+++ b/book/website/community-handbook/accessibility-policy.md
@@ -1,0 +1,10 @@
+(accessibility-policy)=
+# Accessibility Policy
+
+```{note}
+This page is formed from a combination of the [`accessibility.md`](https://github.com/the-turing-way/the-turing-way/blob/main/contributors.md) file and the contributors table in the [`README file`](https://github.com/the-turing-way/the-turing-way#contributors). Pulling these files together into this page requires a little infrastructure wizardry under the hood, which you can read about in the section on {ref}`ch-infrastructure-contributors`.
+```
+
+```{include} ../../../accessibility.md
+```
+

--- a/book/website/community-handbook/accessibility-policy.md
+++ b/book/website/community-handbook/accessibility-policy.md
@@ -2,7 +2,7 @@
 # Accessibility Policy
 
 ```{note}
-This page is formed from a combination of the [`accessibility.md`](https://github.com/the-turing-way/the-turing-way/blob/main/contributors.md) file and the contributors table in the [`README file`](https://github.com/the-turing-way/the-turing-way#contributors). Pulling these files together into this page requires a little infrastructure wizardry under the hood, which you can read about in the section on {ref}`ch-infrastructure-contributors`.
+This page is formed from the [`accessibility.md`](https://github.com/the-turing-way/the-turing-way/blob/main/accessibility.md) in the [`README file`](https://github.com/the-turing-way/the-turing-way#contributors). Rendering this file on this page requires a little infrastructure wizardry under the hood, which you can read about in the section on {ref}`ch-infrastructure-contributors`.
 ```
 
 ```{include} ../../../accessibility.md


### PR DESCRIPTION
### Summary

Added to #3581 - so that we can be rendered in the guides

### List of changes proposed in this PR (pull-request)

* Adds the accessibility policy page to the community handbook
* Adds the policy to our toc

### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

- [ ] Everything looks ok?


### Acknowledging contributors

<!-- Please select the correct box -->

- [ ] All contributors to this pull request are already named in the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
