### PR TITLE
Add licences to myst.yml

### DIFF
--- a/book/website/myst.yml
+++ b/book/website/myst.yml
@@ -10,6 +10,9 @@ project:
   exclude:
     - LICENSE.md
   github: the-turing-way/the-turing-way
+  license:
+    code: MIT
+    content: CC-BY-4.0
   thebe:
     binder:
       repo: the-turing-way/the-turing-way


### PR DESCRIPTION
This should add little buttons to each page that link to the licences we use.

Taken from [here](https://github.com/jupyter-book/mystmd/blob/0ca2c6792b3f83d58942788cf499d495a9e3e73d/docs/myst.yml#L5-L7).