### PR TITLE
fix: use \n\n-- for blockquote attribution

### DIFF
--- a/book/website/project-design/pd-overview.md
+++ b/book/website/project-design/pd-overview.md
@@ -1,4 +1,5 @@
 (pd-overview)=
+
 # Overview of Project Design
 
 ## Summary
@@ -27,7 +28,7 @@ However, often we think about these concepts retrospectively, when the project i
 
 This lack of planning contributes to the fact that most research work can not be directly and independently reproduced, and that communication and collaboration style across different groups differ and hence are challenging.
 
-To help learn good practices, *The Turing Way* provides various chapters for {ref}`reproducibility<rr>`, {ref}`communication<cm>` and {ref}`collaboration<cl>` that we consider essential for research reproducibility.
+To help learn good practices, _The Turing Way_ provides various chapters for {ref}`reproducibility<rr>`, {ref}`communication<cm>` and {ref}`collaboration<cl>` that we consider essential for research reproducibility.
 Although publications{cite:ps}`Turkyilmaz-vanderVelden2020projectdesign` and _The Turing Way_ chapters on specific methods, tools and practices exist it can be overwhelming to know which chapters to read if you don't already know about the concepts.
 
 In this chapter, we have curated essential practices and recommendations and linked them to individual chapters across different guides.
@@ -40,10 +41,12 @@ We invite you to contribute to this chapter by adding important tools or practic
 In the different subchapters we discuss how you can {ref}`start planning<pd-overview-planning>` for project design, the {ref}` communication and collaboration<pd-overview-repro>` aspect for ensuring reproducibility, {ref}`tools and methods<pd-overview-methods>` for reproducibility, {ref}`version control and documentation<pd-overview-version>` aspects and {ref}`sharing your research<pd-overview-sharing>`.
 
 (pd-overview-mistakes)=
+
 ## Learning from Mistakes
 
 > “Building takes many, many mistakes.”
-> ― Becky Chambers, [The Long Way to a Small, Angry Planet](https://www.goodreads.com/work/quotes/42270825)
+>
+> -- Becky Chambers, [The Long Way to a Small, Angry Planet](https://www.goodreads.com/work/quotes/42270825)
 
 Learning about past design mistakes can give us insight into what we can do differently in the future.
 We asked a group of researchers to share what they consider their project design regrets, which we have summarised here:
@@ -60,13 +63,12 @@ We asked a group of researchers to share what they consider their project design
 - Using a very messy excel to store/process data, the shame!
 - Over-engineering a design for features that didn’t end up being implemented (in life before academia!)
 - Not implementing Git flow from the start, and not teaching collaborators how to use Git flow.
-- Not developing tests until after a significant amount of code was written.  
+- Not developing tests until after a significant amount of code was written.
 - Not doing code reviews.
-- Not defining use scenarios for the software from the beginning, meaning we didn’t pay enough attention to data input and output.  
-- Agonising too long before switching to objectively better design (particularly translating from a largely functional codebase to more object-oriented).    
+- Not defining use scenarios for the software from the beginning, meaning we didn’t pay enough attention to data input and output.
+- Agonising too long before switching to objectively better design (particularly translating from a largely functional codebase to more object-oriented).
 - Going with options that team members are ‘comfortable’ with (for example, using outdated languages or platform-dependent compilers), rather than teaching team members new skills. Makes life more difficult in the long run.
 - Defining governance at different stages of the project or potential scenario planning for how governance might change as the project scales up/down/gains new users and so on.
 - Not thinking about community from the start, starting with a Code of Conduct, thinking about a Contributor License Agreement (intellectual property), what processes will be used and how they will work, how they will impact future contributors and the overall project.
 
-_This section summarises participants' notes from a short workshop called "Good Practices for Designing Software Development Projects (The Turing Way)" at the [Collaboration Workshop 2021](https://www.software.ac.uk/cw21)  hosted by [Software Sustainability Institute](https://www.software.ac.uk). The workshop was delivered by Malvika Sharan, Emma Karoune and Batool Almarzouq on 31 March 2021. Zenodo. DOI: [10.5281/zenodo.4650221](https://doi.org/10.5281/zenodo.4650221)._
-
+_This section summarises participants' notes from a short workshop called "Good Practices for Designing Software Development Projects (The Turing Way)" at the [Collaboration Workshop 2021](https://www.software.ac.uk/cw21) hosted by [Software Sustainability Institute](https://www.software.ac.uk). The workshop was delivered by Malvika Sharan, Emma Karoune and Batool Almarzouq on 31 March 2021. Zenodo. DOI: [10.5281/zenodo.4650221](https://doi.org/10.5281/zenodo.4650221)._

--- a/book/website/project-design/pd-overview/pd-overview-repro.md
+++ b/book/website/project-design/pd-overview/pd-overview-repro.md
@@ -1,4 +1,5 @@
 (pd-overview-repro)=
+
 # Collaborative project documentation
 
 Good communication and collaboration practices are complementary to research reproducibility, and often it is hard to separate these concepts from each other.
@@ -17,17 +18,16 @@ It should contain a **recognizable name** for your project, as well as a **decla
 Documentation should be shared via centralised, findable and accessible platforms.
 
 ## Documenting project plans and processes
- 
+
 Document the **current state**, **ongoing development**, and/or any **future plans** for the project.
 Add information on available resources and recommended practices to ensure everyone is on the same page (literally!).
 It may also be important to make it clear what your project is not meant to be.
 
-In addition to the above, it is interesting to document the *principal need* for your project, especially for software and hardware project: what problem are you trying to solve ?
-That includes a **problem description** of whatever issue sparked the project, a **functional description** of how your project is meant to address it, and a **context description** of the users and environment your project is targeting. 
+In addition to the above, it is interesting to document the _principal need_ for your project, especially for software and hardware project: what problem are you trying to solve ?
+That includes a **problem description** of whatever issue sparked the project, a **functional description** of how your project is meant to address it, and a **context description** of the users and environment your project is targeting.
 
-It is particularly important to share the **vision, mission, and milestones** clearly. 
+It is particularly important to share the **vision, mission, and milestones** clearly.
 Provide sufficient information for what the expected outcomes and deliverables are.
-
 
 Provide overarching as well as short-term goals and describe expected outcomes to help contributors move away from focusing on a single idea of the feature.
 Describe the possible expansion of features in pre-determined and agreed on ways at stages beyond the initial implementation.
@@ -35,24 +35,23 @@ Describe the possible expansion of features in pre-determined and agreed on ways
 ## Project's "Who-is-Who"
 
 Include a **list of contributors**, **contribution guidelines**, and information on **contact points** where to ask for help.
-In addition, 
-- Create an overview of  the putative "personas" {ref}`pd-persona` (people and organisations) and how they may interact with the project. 
+In addition,
+
+- Create an overview of the putative "personas" {ref}`pd-persona` (people and organisations) and how they may interact with the project.
 
 Describe what opportunities for collaboration different members will have.
 When possible, such as in an open source project, provide these details for those outside the current group, especially when you want to encourage people outside the project to be involved.
 Communicate the work culture that you want to promote and policies that ensures the safety and security of both your data and people.
-
 
 Provide resources on ways of working to ensure fair participation of contributors who collaborate on short- and long-term milestones within the project.
 It reduces or addresses concerns about the project's progress towards meeting goals and prevents potential fallout between project contributors.
 
 ## Participation and contribution process
 
- In order to make your project discoverable, you may add a machine-readable metadata file, such as an [Open-Know-How manifest](https://www.internetofproduction.org/openknowhow).
+In order to make your project discoverable, you may add a machine-readable metadata file, such as an [Open-Know-How manifest](https://www.internetofproduction.org/openknowhow).
 
 Considering the variety of different backgrounds and skills your members bring, describe how they can participate and start contributing.
 You should also **think about your audience**. Your project might be reused by people with different skills, roles, objectives, and socio-economic and cultural environments.
-
 
 Provide clear opportunities for contributions, review, management, mentoring, and support.
 Provide an overview of how different contributions or resources are connected and how new contributions will fit into existing materials.
@@ -61,7 +60,7 @@ You may also include an index of all the project's documentation, so people can 
 Provide a decision-making framework to facilitate discussions and reaching a shared conclusion.
 In the context of software and hardware, open source projects are often as much about communication as they are about coding or building (if not more).
 Allow informed discussions when a particular project design has reached the end or when it is useful to update it for efficiency and sustainability.
- 
+
 Describe how your research objects are available or will be published and how different contributors will be recognised.
 It helps when everyone feel appreciated and acknowledged for their contribution to the overall vision.
 
@@ -81,12 +80,13 @@ We recommend reading the following chapters to understand effective communicatio
 - {ref}`<>`
 -->
 <!--
-(this section moved to one of the landing pages instead) 
+(this section moved to one of the landing pages instead)
 (pd-overview-repro-mistakes)=
 ## Bonus Section: Learning from Mistakes
 
 > “Building takes many, many mistakes.”
-> ― Becky Chambers, [The Long Way to a Small, Angry Planet](https://www.goodreads.com/work/quotes/42270825)
+>
+> -- Becky Chambers, [The Long Way to a Small, Angry Planet](https://www.goodreads.com/work/quotes/42270825)
 
 Learning about past design mistakes can give us insight into what we can do differently in the future.
 We asked a group of researchers to share what they consider their project design regrets, which we have summarised here:
@@ -103,10 +103,10 @@ We asked a group of researchers to share what they consider their project design
 - Using a very messy excel to store/process data, the shame!
 - Over-engineering a design for features that didn’t end up being implemented (in life before academia!)
 - Not implementing Git flow from the start, and not teaching collaborators how to use Git flow.
-- Not developing tests until after a significant amount of code was written.  
+- Not developing tests until after a significant amount of code was written.
 - Not doing code reviews.
-- Not defining use scenarios for the software from the beginning, meaning we didn’t pay enough attention to data input and output.  
-- Agonising too long before switching to objectively better design (particularly translating from a largely functional codebase to more object-oriented).    
+- Not defining use scenarios for the software from the beginning, meaning we didn’t pay enough attention to data input and output.
+- Agonising too long before switching to objectively better design (particularly translating from a largely functional codebase to more object-oriented).
 - Going with options that team members are ‘comfortable’ with (for example, using outdated languages or platform-dependent compilers), rather than teaching team members new skills. Makes life more difficult in the long run.
 - Defining governance at different stages of the project or potential scenario planning for how governance might change as the project scales up/down/gains new users and so on.
 - Not thinking about community from the start, starting with a Code of Conduct, thinking about a Contributor License Agreement (intellectual property), what processes will be used and how they will work, how they will impact future contributors and the overall project.
@@ -126,7 +126,7 @@ A little work and time investment early on in project design saves a lot of time
 It is really hard for a project to move from practices that were designed for one person to practices that work for a team.
 Therefore, it is essential to document and use practices that will enable collaboration if and when you have to involve others in your project.
 Considering good team practices even for a project run by an individual makes it easy for them to effectively accomplish their goals.
-For example, you can define goals in your project and identify tasks by asking questions like: 
+For example, you can define goals in your project and identify tasks by asking questions like:
 how can my work be split, how will it be reviewed, how will decisions be made, and so on.
 Learn how [agile methodologies](http://www.agilenutshell.com/) help adapt to changes.
 Learn about good team practices in our {ref}`section on teamwork<cl-new-community-teamwork>`.
@@ -135,4 +135,4 @@ Project design does not ensure that everything will always go as planned or ther
 However, it helps you prepare in advance for risk management and to adapt to changes better.
 Also, see [The cost of change curve](http://www.agilemodeling.com/essays/costOfChange.htm) in the context of Software Engineering.
 
-_This chapter summarises participants' notes from a short workshop called "Good Practices for Designing Software Development Projects (The Turing Way)" at the [Collaboration Workshop 2021](https://www.software.ac.uk/cw21)  hosted by [Software Sustainability Institute](https://www.software.ac.uk). The workshop was delivered by Malvika Sharan, Emma Karoune and Batool Almarzouq on 31 March 2021. Zenodo. DOI: [10.5281/zenodo.4650221](https://doi.org/10.5281/zenodo.4650221)._
+_This chapter summarises participants' notes from a short workshop called "Good Practices for Designing Software Development Projects (The Turing Way)" at the [Collaboration Workshop 2021](https://www.software.ac.uk/cw21) hosted by [Software Sustainability Institute](https://www.software.ac.uk). The workshop was delivered by Malvika Sharan, Emma Karoune and Batool Almarzouq on 31 March 2021. Zenodo. DOI: [10.5281/zenodo.4650221](https://doi.org/10.5281/zenodo.4650221)._


### PR DESCRIPTION
<!--
Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
-->
### Summary

Fixes some block-quote styling by using the construct
```markdown
> Text
> 
> -- An attribution
```

Old:
![Image showing current rendering of blockquote, where attribution text is interpreted as body text](https://github.com/user-attachments/assets/51ea35e2-ad9e-4736-868a-90f0d99d2ef0)

New:
![Image showing the new rendering of blockquote, where attribution text is interpreted as a separate attribution](https://github.com/user-attachments/assets/3c004266-db54-4512-a2a8-61dd56765ffc)


### List of changes proposed in this PR (pull-request)

- Block-quote attribution formatting


### What should a reviewer concentrate their feedback on?

- [ ] The formatting looks correct after these changes

### Acknowledging contributors

- [ ] All contributors to this pull request are already named in the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file.
- [x] The following people should be added to the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
