### PR TITLE
Enable Cross-Reference in MyST via CORS

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -14,6 +14,12 @@ else
 fi
 '''
 
+# Enable other sites to access and cross-reference the-turing-way content dynamically
+[[headers]]
+  for = "/*"
+  [headers.values]
+    access-control-allow-origin = "*"
+
 # Redirects for old welcome/home/index page urls to current
 [[redirects]]
   # index.html no longer exists using Jupyter Book 2


### PR DESCRIPTION
This PR updates the Turing Way’s site configuration to allow **Cross-Origin Resource Sharing (CORS)** from all origins (`Access-Control-Allow-Origin: *`). This change is being made to:

* Support **MyST cross-references** (e.g., `xref` links, [see docs](https://mystmd.org/guide/external-references#myst-xref)) **from other sites** that use The Turing Way as a citation source.
* Enable content embedding, linking, or automated metadata access (e.g., for previews or API consumers) **without authentication or same-origin constraints**.

#### What is CORS and why is it needed?

**CORS** is a browser security feature that restricts how resources on a web page can be requested from another domain outside the one that served the web page. For example, JavaScript running on `external-site.org` cannot fetch metadata or assets from `https://book.the-turing-way.org/` unless explicitly allowed.

By setting CORS headers to allow all origins (`*`), we make it possible for external tools and sites to:

* Reference Turing Way content directly via [structured and stable links](https://mystmd.org/guide/external-references#myst-xref).
* Preview or embed sections of the book from that page (with attribution).
* Use it in federated, cross-site knowledge systems (like MyST Markdown references in external books or educational hubs).

Since the Turing Way is **public and does not require authentication**, allowing all origins does **not pose a security risk** and aligns with the project's goals of openness, reusability, and interoperability. This is also the default on GitHub pages as a comparison.