### PR TITLE
Remove .name method call when appending filenames to a list

### DIFF
--- a/tests/lorem-ipsums.py
+++ b/tests/lorem-ipsums.py
@@ -60,7 +60,7 @@ def check_changed_files(pr_num, bad_phrase=BAD_PHRASE):
                 text = f.read()
                 text = remove_comments(text)
                 if bad_phrase in text.lower():
-                    failed.append(filename.name)
+                    failed.append(filename)
         except FileNotFoundError:
             pass
 


### PR DESCRIPTION
<!--
Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
-->
### Summary

<!-- Describe the problem you're trying to fix in this pull request. Please reference any related issue and use fixes/close to automatically close them, if pertinent. For example: "Fixes #58", or "Addresses (but does not close) #238". -->

- related to #4104

The filenames are strings, not path objects, so don't have such a method

### List of changes proposed in this PR (pull-request)

<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->



### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

- [ ] Everything looks ok?


### Acknowledging contributors

<!-- Please select the correct box -->

- [x] All contributors to this pull request are already named in the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
