### PR TITLE
Correct redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -78,49 +78,50 @@ fi
   status = 301
   force = true
 
+# Redirects for old chapter top level pages
+[[redirects]]
+  from = "/reproducible-research"
+  to = "/reproducible-research/reproducible-research"
+  # The default HTTP status code is 301, but you can define a different one.
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/communication"
+  to = "/communication/communication"
+  # The default HTTP status code is 301, but you can define a different one.
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/collaboration"
+  to = "/collaboration/collaboration"
+  # The default HTTP status code is 301, but you can define a different one.
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/project-design"
+  to = "/project-design/project-design"
+  # The default HTTP status code is 301, but you can define a different one.
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/ethical-research"
+  to = "/ethical-research/ethical-research"
+  # The default HTTP status code is 301, but you can define a different one.
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/community-handbook"
+  to = "/community-handbook/community-handbook"
+  # The default HTTP status code is 301, but you can define a different one.
+  status = 301
+  force = true
+
 # Redirects for moved chapters
-[[redirects]]
-  from = "/reproducible-research/*"
-  to = "/reproducible-research/reproducible-research/:splat"
-  # The default HTTP status code is 301, but you can define a different one.
-  status = 301
-  force = true
-
-[[redirects]]
-  from = "/communication/*"
-  to = "/communication/communication/:splat"
-  # The default HTTP status code is 301, but you can define a different one.
-  status = 301
-  force = true
-
-[[redirects]]
-  from = "/collaboration/*"
-  to = "/collaboration/collaboration/:splat"
-  # The default HTTP status code is 301, but you can define a different one.
-  status = 301
-  force = true
-
-[[redirects]]
-  from = "/project-design/*"
-  to = "/project-design/project-design/:splat"
-  # The default HTTP status code is 301, but you can define a different one.
-  status = 301
-  force = true
-
-[[redirects]]
-  from = "/ethical-research/*"
-  to = "/ethical-research/ethical-research/:splat"
-  # The default HTTP status code is 301, but you can define a different one.
-  status = 301
-  force = true
-
-[[redirects]]
-  from = "/community-handbook/*"
-  to = "/community-handbook/community-handbook/:splat"
-  # The default HTTP status code is 301, but you can define a different one.
-  status = 301
-  force = true
-
 [[redirects]]
   from = "/version_control/*"
   to = "/reproducible-research/vcs/:splat"


### PR DESCRIPTION
<!--
Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
-->
### Summary

<!-- Describe the problem you're trying to fix in this pull request. Please reference any related issue and use fixes/close to automatically close them, if pertinent. For example: "Fixes #58", or "Addresses (but does not close) #238". -->

#4045 introduced some problems.
Redirects which were intended to correct the location of the top pages for chapters were made into wildcards. So, for example,

`https://book.the-turing-way.org/reproducible-research/ --> https://book.the-turing-way.org/reproducible-research/reproducible-research` correct
`https://book.the-turing-way.org/reproducible-research/overview --> https://book.the-turing-way.org/reproducible-research/reproducible-research/overview` incorrect

This PR removes those wildcards, but leaves wildcards in place where entire chapters have moved name, for example, `/version_control` to `/reproducible-research/vcs`.


### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

- [ ] Everything looks ok?


### Acknowledging contributors

<!-- Please select the correct box -->

- [ ] All contributors to this pull request are already named in the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
