### PR TITLE
Add updating redirects to the community handbook consistency section

### DIFF
--- a/book/website/community-handbook/style/consistency/consistency-structure.md
+++ b/book/website/community-handbook/style/consistency/consistency-structure.md
@@ -112,3 +112,11 @@ Therefore, to make  _The Turing Way_ easier to read, long chapters should be app
 
 When keeping chapters modular, ensure that its subchapters only talk about one aspect of the overall topic.
 For example, if a chapter on Machine Learning was to be written for _The Turing Way_, such a chapter should contain at least three subchapters that each focus on Supervised Learning, Unsupervised Learning, and Reinforcement Learning.
+
+(ch-consistency-structure-sr-redirects)=
+### Check 3: Add redirects when removing, renaming, or moving chapters or subchapters
+
+To avoid breaking links that other may have made to content in the book if you move, remove or rename a chapter or subchapter please specify a redirect to a suitable new location in the book.
+
+For details of how to specify a redirect please the the [Redirects](#ch-infrastructure-redirects) page.
+

--- a/book/website/community-handbook/style/style-consistency.md
+++ b/book/website/community-handbook/style/style-consistency.md
@@ -65,6 +65,7 @@ Hard | Ensure external sources are properly referenced and included in the centr
 Hard | Do not add any empty files in the `myst.yml`, instead create an issue for new chapters |
 Soft | Ensure each chapter has a good summary on its landing page along with links to its subchapters. |
 Soft | Split long chapters into smaller subchapters so they are modular. |
+Soft | If you delete, change the name of, or move a chapter in `myst.yml` add a [redirect](#ch-infrastructure-redirects) |
 
 
 #### Language


### PR DESCRIPTION
Add updating redirects to the community handbook consistency section with cross-references to the infrastructure section on how to edit redirects. 

https://book.the-turing-way.org/community-handbook/infrastructure/infrastructure-redirects#our-redirects

@JimMadge, @jezcope, & @da5nsy recently updated this and mentioned it in slack and it was a piece of project documentation I'd not come across organically before so thought I should try and add some more cross references to it.

### List of changes proposed in this PR (pull-request)

- Add updating re-directs to the table in the community handbook style guide sub-chapter on maintaining consistency under 'Structure' as a soft requirement
- Add a third check for adding re-directs in the structure sub-section that expands on these steps.

### What should a reviewer concentrate their feedback on?

- [ ] Should this be a soft requirement or a hard one?
- [ ] Everything looks ok?

### Acknowledging contributors

- [ ] All contributors to this pull request are already named in the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
