### PR TITLE
Only run scheduled github workflows on main repository

### DIFF
--- a/.github/workflows/crowdin-contributors.yml
+++ b/.github/workflows/crowdin-contributors.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   crowdin-contributors:
 
+    if: github.repository == 'the-turing-way/the-turing-way'
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/external_link_check.yml
+++ b/.github/workflows/external_link_check.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   external-link-check:
     name: External Link Check
+    if: github.repository == 'the-turing-way/the-turing-way'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout-repository


### PR DESCRIPTION
<!--
Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
-->
### Summary

I noticed that every week I get an email about a couple of failed GH actions in my fork of the TTW repository, which are triggered weekly on a scheduled basis. I get the failures because I have actions enabled but don't have the necessary secrets set up. I've added an `if` condition to the relevant workflows so that they only run on the main repository, which I assume will be the only place those secrets are configured.

### List of changes proposed in this PR (pull-request)

<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

Add `if: github.repository == 'the-turing-way/the-turing-way'` condition to Crowdin contributors and external link check workflows.

### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

Does this have any knock-on consequences that I wasn't aware of? Was anyone else making use of these in their own fork?


### Acknowledging contributors

<!-- Please select the correct box -->

- [x] All contributors to this pull request are already named in the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
