### PR TITLE
Add windows-specific command for local build

### DIFF
--- a/book/website/community-handbook/local-build.md
+++ b/book/website/community-handbook/local-build.md
@@ -56,7 +56,7 @@ $ python3 -m venv ./venv
 Next, active the virtual environment,
 ::::{tab-set}
 :::{tab-item} Unix
-:sync: linux
+:sync: Unix
 ```console
 $ source ./venv/bin/activate
 ```


### PR DESCRIPTION
`source ./venv/bin/activate` does not work in Windows.
An alternative which works for me is `venv\Scripts\activate` (found [here](https://stackoverflow.com/a/61679638/6464224)).

Adding this as a tab set in case there are other OS-specific commands we want to include later. 
Currently everything else works on Windows for me - though, I suspect I have installed some extras (e.g. `make`) previously and so we might want to try and run a build on a fresh install sometime and see if/where it breaks.