### PR TITLE
remove CI path filtering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,6 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - "book/**"
-      - ".github/workflows/**"
-      - "ACCESSIBILITY.md"
-      - "CONTRIBUTING.md"
-      - "contributors.md"
 
 # set the default shell to bash for all jobs
 # this is important for the windows OS!

--- a/.github/workflows/lorem-ipsums.yml
+++ b/.github/workflows/lorem-ipsums.yml
@@ -12,8 +12,6 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - "book/**"
 
 # Set up the Continuous Integration job
 jobs:

--- a/.github/workflows/no-bad-latin.yml
+++ b/.github/workflows/no-bad-latin.yml
@@ -12,8 +12,6 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - "book/**"
 
 # Set up the Continuous Integration job
 jobs:


### PR DESCRIPTION
### Summary

@the-turing-way/infrastructure-working-group recently turned on branch protection rules for `main`, meaning that certain checks would need to pass before merging was allowed.

This had the unintended consequence of blocking certain PRs from being merged (by anyone other than a user with admin permissions who could bypass the branch protection rules). This affected PRs which **only** modified files which were outside of the CI path spec:

https://github.com/the-turing-way/the-turing-way/blob/226f9b2ace7c8dcaccf104999e0cda9eaf836b63/.github/workflows/ci.yml#L11-L16

For example: 
- all-contributors-bot PRs, e.g. https://github.com/the-turing-way/the-turing-way/pull/4276
- things which just change netlify deploy info: https://github.com/the-turing-way/the-turing-way/pull/4156
- others (?)

This is because of [the way github had chosen to implement path filtering](https://docs.github.com/en/actions/how-tos/managing-workflow-runs-and-deployments/managing-workflow-runs/skipping-workflow-runs):

> If a workflow is skipped due to [path filtering](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore), [branch filtering](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpull_requestpull_request_targetbranchesbranches-ignore) or a commit message (see below), then checks associated with that workflow will remain in a "Pending" state. A pull request that requires those checks to be successful will be blocked from merging.

[Previous docs](https://github.com/github/docs/blob/285e455bf41892520fdf2503384bb47cb48e53dd/content/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks.md?plain=1#L58) also said:

> For this reason you should not use path or branch filtering to skip workflow runs if the workflow is required.

### List of changes proposed in this PR (pull-request)

Here I remove the path filtering.

We could hypothetically add in some pseudo-path filtering, using [conditions](https://docs.github.com/en/actions/how-tos/writing-workflows/choosing-when-your-workflow-runs/using-conditions-to-control-job-execution), which is what was recommended in [historic github docs](https://stackoverflow.com/a/78003720/6464224), but I propose not doing that, since our current build time is only ~1 minute. This means that avoiding unnecessary builds is a low priority compared to readability of the CI workflow script.

### What should a reviewer concentrate their feedback on?

Any issues I may not have anticipated.

### Acknowledging contributors

<!-- Please select the correct box -->

- [x] All contributors to this pull request are already named in the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
