### PR TITLE
Simplify conditions for CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,11 @@
 name: CI
 
-# run on pushes and pull requests to main
+# run on pull requests to main, but ignore pull requests from the all-contributors bot
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
+      - "!all-contributors/**"
 
 # set the default shell to bash for all jobs
 # this is important for the windows OS!
@@ -18,7 +16,6 @@ defaults:
 jobs:
   build-jb:
     name: Build
-    if: (github.event.pull_request) && !contains(github.head_ref, 'all-contributors')
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]


### PR DESCRIPTION
<!--
Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
-->
### Summary

<!-- Describe the problem you're trying to fix in this pull request. Please reference any related issue and use fixes/close to automatically close them, if pertinent. For example: "Fixes #58", or "Addresses (but does not close) #238". -->

This PR **does not** change the current behaviour of the CI workflow, but instead makes the syntax more understandable by humans.

### List of changes proposed in this PR (pull-request)

<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

* Removes a job-level `if` condition that prevented the workflow running on pushes to `main` and any PRs opened by the all-contributors bot
* Reimplements the same logic as above but in the `on:` keyword, improving readability for maintainers

### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

- [x] Everything looks ok?

### Acknowledging contributors

<!-- Please select the correct box -->

- [x] All contributors to this pull request are already named in the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
