### PR TITLE
fix: remove BOM in file

### DIFF
--- a/book/website/reproducible-research/overview/overview-resources.md
+++ b/book/website/reproducible-research/overview/overview-resources.md
@@ -1,4 +1,4 @@
-﻿(rr-overview-resources)=
+(rr-overview-resources)=
 # Resources
 For additional resources like videos and reference papers on reproducibility, see the {ref}`rr-overview-resources-reading` and {ref}`rr-overview-resources-addmaterial` sections.
 


### PR DESCRIPTION
### Summary

@stefanv was looking at The Turing Way website, and noticed that a particular file heading doesn't behave properly:

![screenshot of the reproducible research resources page - the markdown title is showing but so too is the label text that should be hidden in the html render](https://github.com/user-attachments/assets/54ac1d01-a208-4338-a1b4-c7b90397e484)

After a little bit of digging, I found a BOM at the head of the file, which is invisible to the human eye but not to the tokeniser:
```
$ cat -v /book/website/reproducible-research/overview/overview-resources.md| head
M-oM-;M-?# Resources

For additional resources like videos and reference papers on reproducibility, see the {ref}`rr-overview-resources-reading` and {ref}`rr-overview-resources-addmaterial` sections.

(rr-overview-resources-learn)=

## What to Learn Next?
```

This PR strips that mark. I searched for other files, and this is the only one affected.

> [!Note]
> Should we introduce a Git hook (pre-commit) to catch this? e.g. https://gist.github.com/rlee287/e6026243dedc38398298
