### PR TITLE
#4274 follow-up: catching a few figure directory refs that slipped through the net

### DIFF
--- a/README-translated/README-Chinese.md
+++ b/README-translated/README-Chinese.md
@@ -1,4 +1,4 @@
-<a href="https://book.the-turing-way.org/welcome.html"><img src="book/website/figures/logo/logo.jpg?raw=true)" width="180" align="Right" /></a>
+<a href="https://book.the-turing-way.org/welcome.html"><img src="book/figures/logo/logo.jpg?raw=true)" width="180" align="Right" /></a>
 
 # _The Turing Way_
 
@@ -22,14 +22,14 @@
 
 _The Turing Way_ 是一本关于可重复的、合乎道德的和协作的数据科学的手册。我们参与并支持由不同贡献者组成的社区，使数据科学对每个人都是可访问的、可理解的和有效的。 我们的目标是提供学术界、工业界和公共部门的研究人员和数据科学家在项目开始时所需的所有信息，以确保项目结束后易于复制。
 
-[![The Turing Way project is a book, community, an open-source project and a culture of collaboration. This is shown in four illustrations, the first one showing the Turing Way book, the second showing how the community can grow, the third one showing two people collaborating on a pull request, the last one is showing a balance where reproducibility is valued more than the number of papers published](../book/website/figures/README_imgs/README_turingway.png)](https://docs.google.com/presentation/d/13Nm8LcRW87ffxEugGEs5j6HKQEvhiuH8b7MfIdX7MpI/edit#slide=id.p1).
+[![The Turing Way project is a book, community, an open-source project and a culture of collaboration. This is shown in four illustrations, the first one showing the Turing Way book, the second showing how the community can grow, the third one showing two people collaborating on a pull request, the last one is showing a balance where reproducibility is valued more than the number of papers published](../book/figures/README_imgs/README_turingway.png)](https://docs.google.com/presentation/d/13Nm8LcRW87ffxEugGEs5j6HKQEvhiuH8b7MfIdX7MpI/edit#slide=id.p1).
 
 *The Turing Way是一本书、一个社区和一个全球合作。*
 
 我们鼓励所有的利益相关者，包括学生、研究人员、软件工程师、项目负责人和融资团队，使用The Turing Way来了解他们在数据科学中的角色和可重复性责任。
 您可以线上阅读这本书 [在线版本](https://book.the-turing-way.org), 按照我们的贡献指南所述为项目做出贡献 [贡献指南](https://github.com/the-turing-way/the-turing-way/blob/main/CONTRIBUTING.md) and 并重新使用所有材料 ([（见许可证）](https://github.com/the-turing-way/the-turing-way/blob/main/LICENSE.md)).
 
-[![This is a screenshot of the online Turing Way book. It also shows one of the Turing Way illustrations at the beginning of the book. In this illustration, there is a road or path with shops for different data science skills. People can go in and out with their shopping cart and pick and choose what they need.](../book/website/figures/README_imgs/README_book.png)](https://book.the-turing-way.org/welcome.html)
+[![This is a screenshot of the online Turing Way book. It also shows one of the Turing Way illustrations at the beginning of the book. In this illustration, there is a road or path with shops for different data science skills. People can go in and out with their shopping cart and pick and choose what they need.](../book/figures/README_imgs/README_book.png)](https://book.the-turing-way.org/welcome.html)
 
 *The Turing Way 线上书籍的截图 ([use this image in a presentation](https://drive.google.com/file/d/1wJR664YECSc8b_RSHeyVjDlHs-Ls9lkc/view?usp=sharing))*
 
@@ -73,7 +73,7 @@ _The Turing Way_ 是一个开放式协作和社区主导的项目。
 我们希望能够满足我们的贡献者的需求。
 因此，我们根据你的兴趣、有效性或技能要求，为你的贡献提供多个切入点。
 
-![This image shows six of many kinds of contributions that anyone can make. These are: Develop and share, Maintain and improve, Share resources, Review and update, Make it global through translation, and Share best practices](../book/website/figures/README_imgs/README_contributions.png)
+![This image shows six of many kinds of contributions that anyone can make. These are: Develop and share, Maintain and improve, Share resources, Review and update, Make it global through translation, and Share best practices](../book/figures/README_imgs/README_contributions.png)
 
 *贡献包括开发和分享新的章节；维护和改进现有的章节；分享 _The Turing Way_ 资源；审查和更新以前开发的材料；翻译其章节，以帮助该项目在全球范围内使用，并分享研究的最佳实践。*
 
@@ -100,7 +100,7 @@ DOI允许我们对资源库进行归档，它们对于确保学术出版物对�
 
 ### 引用 _The Turing Way_ 插图
 
-![This is an example of one of The Turing Way illustrations. It tries to shows the evolution towards an open science era](../book/website/figures/evolution-open-research.jpg)
+![This is an example of one of The Turing Way illustrations. It tries to shows the evolution towards an open science era](../book/figures/evolution-open-research.jpg)
 
 _The Turing Way_ 插图由[Scriberia](https://www.scriberia.co.uk/)的艺术家进行创作，作为[_The Turing Way_ book dashes](https://github.com/the-turing-way/the-turing-way/tree/main/workshops/book-dash)书冲入市场的一部分，分别于 2019 年 5 月 17 日在曼彻斯特、2019 年 5 月 28 日和 2020 年 2 月 21 日在伦敦以及 2020 年 11 月 27 日和 2021 年 5 月 28 日在网上发布。它们描绘了各种 手册中的内容、社区中的协同努力以及 _The Turing Way_ 项目的总体情况。 在 CC-BY 许可下，可在 Zenodo ([https://doi.org/10.5281/zenodo.3332807)](https://doi.org/10.5281/zenodo.3332807)上获得这些插图。
 

--- a/README-translated/README-Dutch.md
+++ b/README-translated/README-Dutch.md
@@ -43,7 +43,7 @@ Dit project is openlijk ontwikkeld en alle vragen, opmerkingen en aanbevelingen 
 Dit is (een deel) van het project team wat aan het werk is op het Turing Institute.
 Voor meer informatie over hoe je ons kan contacteren zie [Governance Roles document](../GOVERNANCE_ROLES.md).
 
-<!---![Team photo](book/website/figures/TuringWayTeam.jpg)--->
+<!---![Team photo](book/figures/TuringWayTeam.jpg)--->
 
 ### Bijdragen
 

--- a/README-translated/README-French.md
+++ b/README-translated/README-French.md
@@ -1,4 +1,4 @@
-<a href="https://book.the-turing-way.org/welcome.html"><img src="https://raw.githubusercontent.com/the-turing-way/the-turing-way/main/book/website/figures/logo/logo.jpg" width="180" align="Right" /></a>
+<a href="https://book.the-turing-way.org/welcome.html"><img src="https://raw.githubusercontent.com/the-turing-way/the-turing-way/main/book/figures/logo/logo.jpg" width="180" align="Right" /></a>
 
 # _The Turing Way_
 
@@ -25,13 +25,13 @@ _The Turing Way_ est un manuel sur la science des données reproductible, éthiq
 Nous impliquons et soutenons une communauté diversifiée de contributeurs et contributrices afin de rendre la science des données accessible, compréhensible et efficace pour tout le monde.
 Notre objectif est de fournir toutes les informations dont les scientifiques ont besoin au début de leurs projets pour s'assurer qu'ils soient faciles à reproduire à la fin.
 
-[![Le projet Turing Way est un livre, une communauté, un projet open-source et une culture de la collaboration. Ceci est démontré par quatre illustrations, la première montrant le livre Turing Way, la deuxième montrant comment la communauté peut se développer, la troisième montrant deux personnes collaborant sur une demande de modification, la dernière montrant un équilibre où la reproductibilité est plus importante que le nombre d'articles publiés](https://raw.githubusercontent.com/the-turing-way/the-turing-way/main/book/website/figures/README_imgs/README_turingway.png)](https://docs.google.com/presentation/d/13Nm8LcRW87ffxEugGEs5j6HKQEvhiuH8b7MfIdX7MpI/edit#slide=id.p1)
+[![Le projet Turing Way est un livre, une communauté, un projet open-source et une culture de la collaboration. Ceci est démontré par quatre illustrations, la première montrant le livre Turing Way, la deuxième montrant comment la communauté peut se développer, la troisième montrant deux personnes collaborant sur une demande de modification, la dernière montrant un équilibre où la reproductibilité est plus importante que le nombre d'articles publiés](https://raw.githubusercontent.com/the-turing-way/the-turing-way/main/book/figures/README_imgs/README_turingway.png)](https://docs.google.com/presentation/d/13Nm8LcRW87ffxEugGEs5j6HKQEvhiuH8b7MfIdX7MpI/edit#slide=id.p1)
 
 *The Turing Way est un livre, une communauté et une collaboration mondiale.*
 
 Toutes les parties prenantes, y compris les étudiants et les étudiantes, les chercheurs et les chercheuses, les ingénieurs et ingénieures logiciels, les chefs et cheffes de projet et les équipes de financement, sont encouragées à utiliser _The Turing Way_ pour comprendre leur rôle et leur responsabilité en matière de reproductibilité dans la science des données. Vous pouvez lire le livre [en ligne](https://book.the-turing-way.org), contribuer au projet tel que décrit dans nos [directives de contribution](https://github.com/the-turing-way/the-turing-way/blob/master/CONTRIBUTING.md) et réutiliser tout le matériel ([voir la licence](https://github.com/the-turing-way/the-turing-way/blob/master/LICENSE.md)).
 
-[![Ceci est une capture d'écran du livre en ligne _The Turing Way_. Elle montre également l'une des illustrations de _The Turing Way_ au début du livre. Dans cette illustration, il y a une route ou un chemin avec des magasins pour différentes compétences en science des données. Les gens peuvent entrer et sortir avec leur panier et choisir ce dont ils ont besoin.](https://raw.githubusercontent.com/the-turing-way/the-turing-way/main/book/website/figures/README_imgs/README_book.png)](https://book.the-turing-way.org/welcome.html)
+[![Ceci est une capture d'écran du livre en ligne _The Turing Way_. Elle montre également l'une des illustrations de _The Turing Way_ au début du livre. Dans cette illustration, il y a une route ou un chemin avec des magasins pour différentes compétences en science des données. Les gens peuvent entrer et sortir avec leur panier et choisir ce dont ils ont besoin.](https://raw.githubusercontent.com/the-turing-way/the-turing-way/main/book/figures/README_imgs/README_book.png)](https://book.the-turing-way.org/welcome.html)
 
 *Capture d'écran du livre en ligne The Turing Way ([utilisez cette image dans une présentation](https://drive.google.com/file/d/1wJR664YECSc8b_RSHeyVjDlHs-Ls9lkc/view?usp=sharing)).*
 
@@ -85,7 +85,7 @@ Tout le monde doit suivre notre [code de conduite](../CODE_OF_CONDUCT.md) et con
 Nous voulons nous assurer que vous êtes à l'aise de contribruer peu importe le niveau de connaissances que vous avez.
 Pour cette raison, nous proposons plusieurs points d'entrée pour que vous puissiez contribuer en fonction de vos intérêts, de votre disponibilité ou des compétences requises.
 
-![Cette image montre six des nombreux types de contributions que chacun peut apporter. Il s'agit de : Développer et partager, Maintenir et améliorer, Partager des ressources, Réviser et mettre à jour, Rendre international par la traduction, et Partager les meilleures pratiques](https://raw.githubusercontent.com/the-turing-way/the-turing-way/main/book/website/figures/README_imgs/README_contributions.png)
+![Cette image montre six des nombreux types de contributions que chacun peut apporter. Il s'agit de : Développer et partager, Maintenir et améliorer, Partager des ressources, Réviser et mettre à jour, Rendre international par la traduction, et Partager les meilleures pratiques](https://raw.githubusercontent.com/the-turing-way/the-turing-way/main/book/figures/README_imgs/README_contributions.png)
 
 *Les contributions comprennent l'élaboration et le partage de nouveaux chapitres, la maintenance et l'amélioration des chapitres existants, le partage des ressources de _The Turing Way_, la révision et la mise à jour du matériel précédemment développé, la traduction de chapitres pour aider à rendre ce projet accessible à l'échelle mondiale, et le partage des meilleures pratiques en matière de recherche*.
 
@@ -113,7 +113,7 @@ Si vous avez des questions, n'hésitez pas à nous [contacter](#entrer-en-contac
 
 ### Citer les illustrations de _The Turing Way_ (en anglais)
 <p align="center">
-  <img src="https://raw.githubusercontent.com/the-turing-way/the-turing-way/main/book/website/figures/evolution-open-research.jpg" alt="Voici un exemple d'une des illustrations du Chemin de Turing. Elle tente de montrer l'évolution vers une ère de science ouverte" width="600">.
+  <img src="https://raw.githubusercontent.com/the-turing-way/the-turing-way/main/book/figures/evolution-open-research.jpg" alt="Voici un exemple d'une des illustrations du Chemin de Turing. Elle tente de montrer l'évolution vers une ère de science ouverte" width="600">.
 </p>
 
 Les illustrations de _The Turing Way_ sont créées par des artistes de [Scriberia](https://www.scriberia.co.uk/) dans le cadre de [_The Turing Way_ book dashes](https://github.com/the-turing-way/the-turing-way/tree/master/workshops/book-dash) à Manchester le 17 mai 2019, à Londres le 28 mai 2019 et le 21 février 2020, et en ligne le 27 novembre 2020 et le 28 mai 2021.

--- a/README-translated/README-German.md
+++ b/README-translated/README-German.md
@@ -58,7 +58,7 @@ sind herzlich willkommen und können über das GitHub Repository <https://github
 Dies ist ein Teil des Teams, das am Turing Institut mitarbeitet.
 Für Informationen darüber, wie man uns kontaktiert, lesen Sie bitte die [Governance Roles document](../GOVERNANCE_ROLES.md).
 
-![Team photo](book/website/figures/TuringWayTeam.jpg)
+![Team photo](book/figures/TuringWayTeam.jpg)
 
 ### Mitarbeiten
 

--- a/README-translated/README-Italian.md
+++ b/README-translated/README-Italian.md
@@ -1,4 +1,4 @@
-<a href="https://book.the-turing-way.org/welcome.html"><img src="/book/website/figures/logo/logo.jpg?raw=true)" width="180" align="Right" /></a>
+<a href="https://book.the-turing-way.org/welcome.html"><img src="/book/figures/logo/logo.jpg?raw=true)" width="180" align="Right" /></a>
 
 # _The Turing Way_
 
@@ -19,14 +19,14 @@ _Benvenuti nel GitHub repository per The Turing Way. Qui è dove tutte le parti 
 
 _The Turing Way_ è una guida per condurre data science in maniera riproducibile, etica e collaborativa. Coinvolgiamo e sosteniamo una comunità eterogenea di contributori in modo da rendere data science accessibile, comprensibile ed efficace per tutti. Il nostro obiettivo è quello di fornire tutte le informazioni di cui i ricercatori e i data scientists (che siano in ambito accademico, industriale o nel settore pubblico) hanno bisogno all'inizio dei loro progetti in modo che questi siano poi facili da riprodurre.
 
-[![The Turing Way project è un libro, una comunità, un progetto open-source e una cultura collaborativa. Questo è illustrato in quattro figure. La prima mostra il libro "the Turing Way", la seconda spiega come la comunità può crescere, la terza figura rappresenta due persone che collaborano per una pull request, l'ultima illustra l'equilibrio dove la reproducibilità è considerata più importante del numero di articoli pubblicati.](/book/website/figures/README_imgs/README_turingway.png)](https://docs.google.com/presentation/d/13Nm8LcRW87ffxEugGEs5j6HKQEvhiuH8b7MfIdX7MpI/edit#slide=id.p1).
+[![The Turing Way project è un libro, una comunità, un progetto open-source e una cultura collaborativa. Questo è illustrato in quattro figure. La prima mostra il libro "the Turing Way", la seconda spiega come la comunità può crescere, la terza figura rappresenta due persone che collaborano per una pull request, l'ultima illustra l'equilibrio dove la reproducibilità è considerata più importante del numero di articoli pubblicati.](/book/figures/README_imgs/README_turingway.png)](https://docs.google.com/presentation/d/13Nm8LcRW87ffxEugGEs5j6HKQEvhiuH8b7MfIdX7MpI/edit#slide=id.p1).
 
 *The Turing Way è un libro, una comunità e una collaborazione globale.*
 
 Tutte le parti interessate, tra cui studenti, ricercatori, software engineers, capi progetto e team di finanziamento, sono incoraggiati a usare _The Turing Way_ per capire i propri ruoli e responsabilità nella riproducibilità in data science. 
 Puoi leggere il libro [online](https://github.com/the-turing-way/the-turing-way), contribuire al progetto come dettagliato in [questa guida](/CONTRIBUTING.md) e riusare tutti i materiali (controlla la [licenza](https://github.com/the-turing-way/the-turing-way/blob/main/LICENSE.md)).
 
-[![Questo è uno screenshot del libro online. Mostra una delle illustrazioni all'inizio del libro. In questa figura, c'è una strada dove ci sono negozi per le varie data science skills. I clienti, con il loro carrello, possono entrare e uscire a loro piacimento e scegliere ciò che gli serve.](/book/website/figures/README_imgs/README_book.png)](https://book.the-turing-way.org/welcome.html)
+[![Questo è uno screenshot del libro online. Mostra una delle illustrazioni all'inizio del libro. In questa figura, c'è una strada dove ci sono negozi per le varie data science skills. I clienti, con il loro carrello, possono entrare e uscire a loro piacimento e scegliere ciò che gli serve.](/book/figures/README_imgs/README_book.png)](https://book.the-turing-way.org/welcome.html)
 
 *Screenshot del libro The Turing Way online ([usa questa immagine in una presentazione](https://drive.google.com/file/d/1wJR664YECSc8b_RSHeyVjDlHs-Ls9lkc/view?usp=sharing))*
 
@@ -77,7 +77,7 @@ Tutti sono tenuti a seguire il nostro [codice di condotta](CODE_OF_CONDUCT.md) e
 Vogliamo rendere la contribuzione a questo progetto il più facile possibile.
 Per questo motivo, ci sono diversi modi in cui è possibile contribuire in base ai propri interessi, disponibilità e capacità.
 
-![Questa immagine mostra sei dei diversi modi in cui chiunque può contribuire. Questi sono: sviluppare e condividere, mantenere e migliorare, condividere risorse, revisionare e aggiornare, rendere il progetto globale attraverso la traduzione, e condividere le migliori pratiche.](/book/website/figures/README_imgs/README_contributions.png)
+![Questa immagine mostra sei dei diversi modi in cui chiunque può contribuire. Questi sono: sviluppare e condividere, mantenere e migliorare, condividere risorse, revisionare e aggiornare, rendere il progetto globale attraverso la traduzione, e condividere le migliori pratiche.](/book/figures/README_imgs/README_contributions.png)
 
 *Tra i modi di contribuire ci sono anche lo sviluppo e la condivisione di nuovi capitoli, la manutenzione e il miglioramento dei capitoli esistenti, la condivisione delle risorse de _The Turing Way_, la revisione e l'aggiornamento del materiale, la traduzione dei capitoli per rendere questo progetto accessibile globalmente, la condivisione delle miglior pratiche nell'amito della ricerca.*
 

--- a/README-translated/README-Korean.md
+++ b/README-translated/README-Korean.md
@@ -1,4 +1,4 @@
-<a href="https://book.the-turing-way.org/welcome.html"><img src="book/website/figures/logo/logo.jpg?raw=true)" width="180" align="Right" /></a>
+<a href="https://book.the-turing-way.org/welcome.html"><img src="book/figures/logo/logo.jpg?raw=true)" width="180" align="Right" /></a>
 
 # _The Turing Way_
 [![Read the book](https://img.shields.io/badge/read-the%20book-blue.svg)](https://book.the-turing-way.org)
@@ -27,12 +27,12 @@
 
 _The Turing Way_ 는 재현 가능하고 윤리적이며 협력적인 데이터 과학에 대한 안내서입니다. 우리는 다양한 기여자로 구성된 커뮤니티에 참여하고 지원하여 데이터 과학이 모든 사람에게 접근 가능하고 이해하기 쉽고 효과적이도록 합니다. 우리의 목표는 학계, 산업 및 공공 부문의 연구자들과 데이터 과학자들이 프로젝트를 시작할 때 필요한 모든 정보를 제공하여 프로젝트가 끝난 후에도 쉽게 재현할 수 있도록 하는 것입니다
 
-[![The Turing Way 프로젝트는 한 권의 책, 커뮤니티, 오픈 소스 프로젝트이자 협업 문화입니다. 이는 네 가지 일러스트레이션을 통해 나타납니다. 첫 번째는 The Turing Way 책을 보여주고, 두 번째는 커뮤니티가 성장하는 모습을 보여주며, 세 번째는 두 사람이 풀 리퀘스트에서 협업하는 모습을 보여줍니다. 마지막 네 번째는 발표된 논문 수보다 재현성을 더 중요하게 평가하는 균형을 보여줍니다.](../book/website/figures/README_imgs/README_turingway.png)](https://docs.google.com/presentation/d/13Nm8LcRW87ffxEugGEs5j6HKQEvhiuH8b7MfIdX7MpI/edit#slide=id.p1).
+[![The Turing Way 프로젝트는 한 권의 책, 커뮤니티, 오픈 소스 프로젝트이자 협업 문화입니다. 이는 네 가지 일러스트레이션을 통해 나타납니다. 첫 번째는 The Turing Way 책을 보여주고, 두 번째는 커뮤니티가 성장하는 모습을 보여주며, 세 번째는 두 사람이 풀 리퀘스트에서 협업하는 모습을 보여줍니다. 마지막 네 번째는 발표된 논문 수보다 재현성을 더 중요하게 평가하는 균형을 보여줍니다.](../book/figures/README_imgs/README_turingway.png)](https://docs.google.com/presentation/d/13Nm8LcRW87ffxEugGEs5j6HKQEvhiuH8b7MfIdX7MpI/edit#slide=id.p1).
 
 The Turing Way는 한 권의 책이자 커뮤니티이며 전 세계적인 협업입니다.
 
 우리는 학생, 연구원, 소프트웨어 엔지니어, 프로젝트 매니저 및 자금 조달 팀을 포함한 모든 이해 관계자들이 데이터 과학에서의 역할과 반복 가능성에 대한 책임을 이해하기 위해 The Turing Way를 사용하도록 권장합니다. 이 책은 온라인 버전으로 읽을 수 있으며, 우리의 기여 가이드에 따라 프로젝트에 기여할 수 있습니다. 또한 모든 자료를 재사용할 수 있습니다 (라이선스 참조).
-[![이것은 온라인 The Turing Way 책의 스크린샷입니다. 또한 책의 시작 부분에 있는 The Turing Way 일러스트 중 하나를 보여줍니다. 이 일러스트에서는 다양한 데이터 과학 기술을 위한 상점이 있는 도로나 길이 있습니다. 사람들은 쇼핑 카트를 가지고 들어가 필요한 것을 골라 살 수 있습니다.](../book/website/figures/README_imgs/README_book.png)](https://book.the-turing-way.org/welcome.html)
+[![이것은 온라인 The Turing Way 책의 스크린샷입니다. 또한 책의 시작 부분에 있는 The Turing Way 일러스트 중 하나를 보여줍니다. 이 일러스트에서는 다양한 데이터 과학 기술을 위한 상점이 있는 도로나 길이 있습니다. 사람들은 쇼핑 카트를 가지고 들어가 필요한 것을 골라 살 수 있습니다.](../book/figures/README_imgs/README_book.png)](https://book.the-turing-way.org/welcome.html)
 
 *The Turing Way 온라인 책의 스크린샷*
 
@@ -77,7 +77,7 @@ _The Turing Way_는 개방형 협업 및 커뮤니티 주도 프로젝트입니�
 우리는 기여자의 요구를 충족할 수 있기를 원합니다.
 따라서 우리는 귀하의 관심사, 가용성 또는 기술 요구 사항에 따라 귀하의 기여에 대한 여러 진입점을 제공합니다.
 
-![This image shows six of many kinds of contributions that anyone can make. These are: Develop and share, Maintain and improve, Share resources, Review and update, Make it global through translation, and Share best practices](../book/website/figures/README_imgs/README_contributions.png)
+![This image shows six of many kinds of contributions that anyone can make. These are: Develop and share, Maintain and improve, Share resources, Review and update, Make it global through translation, and Share best practices](../book/figures/README_imgs/README_contributions.png)
 
 [프로모션 정보 팩](https://github.com/the-turing-way/the-turing-way/tree/main/communications/promotion-pack)는 _The Turing Way_ 네트워크 를 소개하고 공유하는 데 도움이 됩니다.
 
@@ -102,7 +102,7 @@ DOI를 사용하면 리포지토리를 보관할 수 있으며 학술 출판물�
 귀하의 작업에서 Turing Way 프로젝트를 참고하시면 매우 감사하겠습니다. 도움이 되기를 바랍니다. 궁금한 점이 있으시면 [문의](#get-in-touch)해 주세요.
 
 ### 명언 _Turing Way_ 일러스트레이션
-![이것은 개방형 과학 시대를 향한 진화를 보여주려는 튜링 방식 삽화 중 하나의 예입니다.](../book/website/Figures/evolution-open-research.jpg)
+![이것은 개방형 과학 시대를 향한 진화를 보여주려는 튜링 방식 삽화 중 하나의 예입니다.](../book/figures/evolution-open-research.jpg)
 
 _The Turing Way_ 일러스트레이션은 [Scriberia](https://www.scriberia.co.uk/)의 아티스트가 [_The Turing Way_ 북 대시](https://github.com/the-turing-way/)로 제작했습니다. -turing-way/tree/main/workshops/book-dash) 책은 2019년 5월 17일 맨체스터, 2019년 5월 28일, 2020년 2월 21일 런던에서 출시되며 2020년 11월 27일과 2021년 5월 28일에 온라인으로 출판되었습니다. 다양한 핸드북의 내용, 커뮤니티의 공동 노력, Turing Way 프로젝트의 전반적인 그림을 설명합니다. 이 그림은 CC-BY 라이선스에 따라 Zenodo([https://doi.org/10.5281/zenodo.3332807)](https://doi.org/10.5281/zenodo.3332807)에서 볼 수 있습니다.
 

--- a/README-translated/README-Portuguese.md
+++ b/README-translated/README-Portuguese.md
@@ -45,7 +45,7 @@ Este projeto é desenvolvido abertamente e todas e quaisquer perguntas, comentá
 Estes são alguns membros do projeto realizando planejamentos no Instituto Turing (*Turing Institute*).
 Para mais informações sobre como nos contatar, consulte o [Governance Roles document](../GOVERNANCE_ROLES.md).
 
-<!---![Foto da equipe](book/website/figures/TuringWayTeam.jpg)--->
+<!---![Foto da equipe](book/figures/TuringWayTeam.jpg)--->
 
 ### Como contribuir
 

--- a/README-translated/README-Spanish.md
+++ b/README-translated/README-Spanish.md
@@ -1,4 +1,4 @@
-<a href="https://book.the-turing-way.org/welcome.html"><img src="../book/website/figures/logo/logo.jpg?raw=true)" width="180" align="Right" /></a>
+<a href="https://book.the-turing-way.org/welcome.html"><img src="../book/figures/logo/logo.jpg?raw=true)" width="180" align="Right" /></a>
 
 # _The Turing Way_
 
@@ -21,14 +21,14 @@ _The Turing Way_ es una guía práctica para la ciencia de datos reproducible, �
 Apoyamos una comunidad diversa de colaboradores para conseguir una ciencia de datos accesible, comprensible y efectiva para todos.
 Nuestro objetivo es proporcionar toda la información que los investigadores y científicos de datos en la academia, la industria y el sector público necesitan al inicio de sus proyectos para asegurar que sean fáciles de reproducir al final.
 
-[![El proyecto The Turing Way es un libro, una comunidad, un proyecto de código abierto y una cultura de colaboración. Esto se muestra en cuatro ilustraciones, la primera mostrando el libro de Turing Way, la segunda cómo la comunidad puede crecer, la tercera mostrando dos personas colaborando en una pull request, y la última mostrando el balance donde la reproducibilidad es valorada en mayor medida que el número de documentos publicados](../book/website/figures/README_imgs/README_turingway.png)](https://docs.google.com/presentation/d/13Nm8LcRW87ffxEugGEs5j6HKQEvhiuH8b7MfIdX7MpI/edit#slide=id.p1).
+[![El proyecto The Turing Way es un libro, una comunidad, un proyecto de código abierto y una cultura de colaboración. Esto se muestra en cuatro ilustraciones, la primera mostrando el libro de Turing Way, la segunda cómo la comunidad puede crecer, la tercera mostrando dos personas colaborando en una pull request, y la última mostrando el balance donde la reproducibilidad es valorada en mayor medida que el número de documentos publicados](../book/figures/README_imgs/README_turingway.png)](https://docs.google.com/presentation/d/13Nm8LcRW87ffxEugGEs5j6HKQEvhiuH8b7MfIdX7MpI/edit#slide=id.p1).
 
 *The Turing Way es un libro, una comunidad y una colaboración global.*
 
 Todas las partes interesadas, incluyendo estudiantes, investigadores/as, ingenieros/as de software, líderes de proyectos y equipos fundadores, están invitados/as a usar The Turing Way para entender sus roles y sus responsabilidades en la reproducibilidad de la ciencia de datos.
 Puede leer el libro [online](https://github.com/the-turing-way/the-turing-way), contribuir al proyecto tal como se describe en nuestras [guías para contribuir al proyecto](https://github.com/the-turing-way/the-turing-way/blob/main/CONTRIBUTING.md) y reutilizar todos los materiales ([ver la Licencia](https://github.com/the-turing-way/the-turing-way/blob/main/LICENSE.md)).
 
-[![Captura de pantalla del libro en línea de Turing Way. También muestra una de las ilustraciónes de Turing Way al comienzo del libro. En esta ilustración, podemos ver una carretera o camino con tiendas para las diferentes habilidades de ciencia de datos. La gente puede entrar y salir con su lista de la compra y escoger lo que necesiten.](../book/website/figures/README_imgs/README_book.png)](https://book.the-turing-way.org/welcome.html)
+[![Captura de pantalla del libro en línea de Turing Way. También muestra una de las ilustraciónes de Turing Way al comienzo del libro. En esta ilustración, podemos ver una carretera o camino con tiendas para las diferentes habilidades de ciencia de datos. La gente puede entrar y salir con su lista de la compra y escoger lo que necesiten.](../book/figures/README_imgs/README_book.png)](https://book.the-turing-way.org/welcome.html)
 
 *Captura de pantalla del libro en línea de The Turing Way ([usar esta imagen en una presentación](https://drive.google.com/file/d/1wJR664YECSc8b_RSHeyVjDlHs-Ls9lkc/view?usp=sharing))*
 
@@ -81,7 +81,7 @@ Se espera que todas las personas que deseen unirse al proyecto sigan nuestro [c�
 Queremos conocer a nuestros colaboradores allá donde estén.
 Por lo tanto, proporcionamos múltiples puntos de entrada para que puedas colaborar basados en tus intereses, disponibilidad o habilidades.
 
-![Esta imagen muestra seis tipos de contribuciones que cualquiera puede hacer. Éstas son: Desarrollar y compartir, Mantener y mejorar, Compartir recursos, Revisar y actualizar, Hacerlo global mediante traducciones, y Compartir las mejores prácticas](../book/website/figures/README_imgs/README_contributions.png)
+![Esta imagen muestra seis tipos de contribuciones que cualquiera puede hacer. Éstas son: Desarrollar y compartir, Mantener y mejorar, Compartir recursos, Revisar y actualizar, Hacerlo global mediante traducciones, y Compartir las mejores prácticas](../book/figures/README_imgs/README_contributions.png)
 
 Las contribuciones incluyen el desarrollo y difusión de nuevos capítulos; matenimiento y mejora de capítulos existentes; compartir recursos de _The Turing Way_; revisar y actualizar materiales anteriormente desarrollados; traducir los capítulos para ayudar a hacer este proyecto accesible de forma global, y compartir las mejores prácticas en la investigación.
 
@@ -107,7 +107,7 @@ Si tienes alguna pregunta por favor [contáctanos](#get-in-touch).
 
 ### Citando las ilustraciones de _The Turing Way_
 <p align="center">
-  <img src="../book/website/figures/evolution-open-research.jpg" alt="Esto es un ejemplo de una de las ilustraciones de The Turing Way. Intenta mostrar la evolución frente a la era de la ciencia abierta" width="600">
+  <img src="../book/figures/evolution-open-research.jpg" alt="Esto es un ejemplo de una de las ilustraciones de The Turing Way. Intenta mostrar la evolución frente a la era de la ciencia abierta" width="600">
 </p>
 
 Las ilustraciones del _The Turing Way_ se han creado por artistas de [Scriberia](https://www.scriberia.co.uk/) como parte de [_The Turing Way_ book dashes](https://github.com/the-turing-way/the-turing-way/tree/main/workshops/book-dash) en Manchester el 17 de mayo de 2019, en Londres el 28 de mayo de 2019 y el 21 de febrero de 2020.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<a href="https://book.the-turing-way.org/welcome.html"><img src="book/website/figures/logo-detail-with-text.svg?raw=true)" width="180" align="Right" /></a>
+<a href="https://book.the-turing-way.org/welcome.html"><img src="book/figures/logo-detail-with-text.svg?raw=true)" width="180" align="Right" /></a>
 
 # _The Turing Way_
 
@@ -25,7 +25,7 @@ _The Turing Way_ is a handbook to reproducible, ethical and collaborative data s
 We involve and support a diverse community of contributors to make data science accessible, comprehensible and effective for everyone.
 Our goal is to provide all the information that researchers and data scientists in academia, industry and the public sector need at the start of their projects to ensure that they are easy to reproduce at the end.
 
-[![The Turing Way project is a book, community, an open-source project and a culture of collaboration. This is shown in four illustrations, the first one showing the Turing Way book, the second showing how the community can grow, the third one showing two people collaborating on a pull request, the last one is showing a balance where reproducibility is valued more than the number of papers published](book/website/figures/README_imgs/README_turingway.png)](https://docs.google.com/presentation/d/13Nm8LcRW87ffxEugGEs5j6HKQEvhiuH8b7MfIdX7MpI/edit#slide=id.p1)
+[![The Turing Way project is a book, community, an open-source project and a culture of collaboration. This is shown in four illustrations, the first one showing the Turing Way book, the second showing how the community can grow, the third one showing two people collaborating on a pull request, the last one is showing a balance where reproducibility is valued more than the number of papers published](book/figures/README_imgs/README_turingway.png)](https://docs.google.com/presentation/d/13Nm8LcRW87ffxEugGEs5j6HKQEvhiuH8b7MfIdX7MpI/edit#slide=id.p1)
 
 *The Turing Way is a book, a community and a global collaboration.*
 
@@ -34,7 +34,7 @@ You can read the book [online](https://book.the-turing-way.org), contribute to t
 **We also invite you to contribute to the translation of _The Turing Way_ into different languages and help make research reproducibility accessible to a wider global audience**. 
 If you are interested in contributing, please refer to [the guidelines provided in the book's handbook](https://book.the-turing-way.org/community-handbook/translation.html) and join our collaborative efforts.
 
-[![This is a screenshot of the online Turing Way book. It also shows one of the Turing Way illustrations at the beginning of the book. In this illustration, there is a road or path with shops for different data science skills. People can go in and out with their shopping cart and pick and choose what they need.](book/website/figures/README_imgs/README_book.png)](https://book.the-turing-way.org/welcome.html)
+[![This is a screenshot of the online Turing Way book. It also shows one of the Turing Way illustrations at the beginning of the book. In this illustration, there is a road or path with shops for different data science skills. People can go in and out with their shopping cart and pick and choose what they need.](book/figures/README_imgs/README_book.png)](https://book.the-turing-way.org/welcome.html)
 
 *Screenshot of The Turing Way online book ([use this image in a presentation](https://drive.google.com/file/d/1wJR664YECSc8b_RSHeyVjDlHs-Ls9lkc/view?usp=sharing))*
 
@@ -93,7 +93,7 @@ Everyone who joins the project is expected to follow our [code of conduct](CODE_
 We want to meet our contributors where they are.
 Therefore, we provide multiple entry points for you to contribute based on your interest, availability or skill requirements.
 
-![This image shows six of many kinds of contributions that anyone can make. These are: Develop and share, Maintain and improve, Share resources, Review and update, Make it global through translation, and Share best practices](book/website/figures/README_imgs/README_contributions.png)
+![This image shows six of many kinds of contributions that anyone can make. These are: Develop and share, Maintain and improve, Share resources, Review and update, Make it global through translation, and Share best practices](book/figures/README_imgs/README_contributions.png)
 
 *Contributions include development and sharing of new chapters; maintenance and improvement of existing chapters; sharing _The Turing Way_ resources; review and updating of previously developed materials; translating its chapter to help make this project globally accessible, and sharing best practices in research.*
 

--- a/book/README.md
+++ b/book/README.md
@@ -4,7 +4,7 @@ This is the README file for _The Turing Way_ book hosted online at https://book.
 For the README file of the main repository please [follow this link](https://github.com/the-turing-way/the-turing-way/blob/main/README.md).
 
 All the text for each chapter of the `book` lives inside the folder `./website` directory.
-All figures associated to the chapters are stored in and linked from the `./website/figures` directory.
+All figures associated to the chapters are stored in and linked from the `./figures` directory.
 Everything else is in the `website/` directory.
 
 ### Configuration

--- a/book/website/community-handbook/bookdash/bookdash-illustrator.md
+++ b/book/website/community-handbook/bookdash/bookdash-illustrator.md
@@ -25,7 +25,7 @@ Picture taken by Jez Cope at the Book Dash 2019 in Manchester. Hand sketched ill
 ```
 
 All illustrations generated within *The Turing Way* are shared under the CC-BY 4.0 licence on Zenodo: [https://zenodo.org/record/3332807](https://zenodo.org/record/3332807).
-All images on Zenodo are shared in the original format and size, but we use smaller files in *The Turing Way* guides that you can find in [our GitHub repository](https://github.com/the-turing-way/the-turing-way/tree/main/book/website/figures).
+All images on Zenodo are shared in the original format and size, but we use smaller files in *The Turing Way* guides that you can find in [our GitHub repository](https://github.com/the-turing-way/the-turing-way/tree/main/book/figures).
 
 When citing, please include the following attribution with the specific DOI as listed on the particular Zenodo page.
 > _This illustration is created by Scriberia with The Turing Way community. Used under a CC-BY 4.0 licence. DOI: [10.5281/zenodo.3332807](https://doi.org/10.5281/zenodo.3332807)_

--- a/book/website/community-handbook/style/style-figures.md
+++ b/book/website/community-handbook/style/style-figures.md
@@ -30,7 +30,7 @@ In general, make sure to always cite the image properly as directed by the image
 (ch-style-figures-image)=
 ## Image location, type, size and file name
 
-Every image file used in this book should be located in the directory `book/website/figures` of our [GitHub Repository](https://github.com/the-turing-way/the-turing-way/tree/main/book/website/figures).
+Every image file used in this book should be located in the directory `book/website/figures` of our [GitHub Repository](https://github.com/the-turing-way/the-turing-way/tree/main/book/figures).
 If you use a new image file, please add the file in the `figures` directory by either uploading via GitHub, or adding locally and pushing the change online when using git.
 
 Please upload `.jpg`, `.png`, or `.svg` files that are under 1MB to allow them to load faster in the online book.


### PR DESCRIPTION
_Pulled out of https://github.com/the-turing-way/the-turing-way/pull/4289 to allow https://github.com/the-turing-way/the-turing-way/pull/4290 to be cleaner._

Follows #4274 - catches a few files which were missed, either because:
- they're at a higher-than-book level (the readme files)
- they are references to the `figures` dir itself (without a following `/`) and so weren't picked up by my previous search.