### PR TITLE
Update references.bib

### DIFF
--- a/book/website/references.bib
+++ b/book/website/references.bib
@@ -1225,7 +1225,7 @@
   author = {Zhang, Brian Hu and Lemoine, Blake and Mitchell, Margaret},
   year = {2018},
   month = dec,
-  series = {{{AIES}} '18},
+  series = {AIES '18},
   pages = {335--340},
   publisher = {{Association for Computing Machinery}},
   address = {{New York, NY, USA}},


### PR DESCRIPTION
excluding { } in reference.bib as it causes a crash when including it in own book JB using -external (See https://teachbooks.io/manual/features/external_toc.html)
