### PR TITLE
Update malformed references.bib

### DIFF
--- a/book/website/references.bib
+++ b/book/website/references.bib
@@ -1232,7 +1232,7 @@
   doi = {10/gftmfb},
   isbn = {978-1-4503-6012-8},
 }
-=======
+
 @article {wislar2011honorary,
 	author = {Wislar, Joseph S and Flanagin, Annette and Fontanarosa, Phil B and DeAngelis, Catherine D},
 	title = {Honorary and ghost authorship in high impact biomedical journals: a cross sectional survey},
@@ -2168,7 +2168,7 @@ numpages = {10}
   pages = {482--484},
   author = {Myriam Vidal Valero},
   title = {Thousands of scientists are cutting back on {T}witter, seeding angst and uncertainty},
-  journal = {Nature 🔒}
+  journal = {Nature}
 }
 
 @article{Hiltzik2023twitter,


### PR DESCRIPTION
icon and ==== are breaking embedding reference.bib in different repositories.