### PR TITLE
Correct secret name in crowdin workflow

### DIFF
--- a/.github/workflows/crowdin-contributors.yml
+++ b/.github/workflows/crowdin-contributors.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.CROWDIN_ACTION_TOKEN }}
           title: Update Crowdin Contributors table
           body: By [action-crowdin-contributors](https://github.com/andrii-bodnar/action-crowdin-contributors) GitHub action
           commit-message: Update Crowdin Contributors table


### PR DESCRIPTION
This reverts commit ff21cd7f46328b4d5c068083d2ddd50b8d21909a.

Forgot to do this in #4323 