### PR TITLE
Fix website edit button redirect by specify the full URL

### DIFF
--- a/book/website/myst.yml
+++ b/book/website/myst.yml
@@ -9,7 +9,7 @@ project:
   copyright: 2019-2025
   exclude:
     - LICENSE.md
-  github: the-turing-way/the-turing-way
+  github: https://github.com/the-turing-way/the-turing-way
   license:
     code: MIT
     content: CC-BY-4.0


### PR DESCRIPTION
<!--
Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
-->
### Summary

<!-- Describe the problem you're trying to fix in this pull request. Please reference any related issue and use fixes/close to automatically close them, if pertinent. For example: "Fixes #58", or "Addresses (but does not close) #238". -->

Fixes #4246

*Makes a small change to the MyST configuration to make the edit button on the website to redirect to the main branch as intended.*

### List of changes proposed in this PR (pull-request)

<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

* Updates the `github` field in the MyST configuration to the full repository URL rather than just the org/repo

In full transparency, I'm not entirely sure why this works as intended and the other option doesn't, but I have confirmed with a local build that's the case and have not had the issue on other projects where we specify the full URL.  

### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

If there was a particular reason the other format was chosen initially, that would be helpful context here potentially.    

### Acknowledging contributors

<!-- Please select the correct box -->

- [ ] All contributors to this pull request are already named in the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
