### PR TITLE
MAINT: cleanup latin style guide pointers

### DIFF
--- a/book/website/community-handbook/style/consistency/consistency-language.md
+++ b/book/website/community-handbook/style/consistency/consistency-language.md
@@ -47,6 +47,6 @@ This makes _The Turing Way_ less distracting and easier to read.
 When writing content for _The Turing Way_, the use of Latin abbreviations is discouraged.
 This is because screen readers may read them aloud in a manner that is confusing to those who rely on such devices.
 
-Furthermore, as described in the {ref}`style guide<ch-style>`, contributions that contain Latin abbreviations will fail the _The Turing Way_ repository's continuous integration workflow.
+Please refer to the {ref}`style guide<ch-style-writing-markdown-latin>` for recommendations on how to avoid common Latin abbreviations in your writing.
 
-Please refer to the {ref}`style guide<ch-style>` for recommendations on how to avoid common Latin abbreviations in your writing.
+To enforce this consistency, contributions that contain Latin abbreviations will fail the _The Turing Way_ repository's continuous integration workflow.

--- a/book/website/community-handbook/style/consistency/consistency-language.md
+++ b/book/website/community-handbook/style/consistency/consistency-language.md
@@ -47,6 +47,6 @@ This makes _The Turing Way_ less distracting and easier to read.
 When writing content for _The Turing Way_, the use of Latin abbreviations is discouraged.
 This is because screen readers may read them aloud in a manner that is confusing to those who rely on such devices.
 
-Please refer to the {ref}`style guide<ch-style-writing-markdown-latin>` for recommendations on how to avoid common Latin abbreviations in your writing.
+Please refer to the [style guide](#ch-style-writing-markdown-latin) for recommendations on how to avoid common Latin abbreviations in your writing.
 
 To enforce this consistency, contributions that contain Latin abbreviations will fail the _The Turing Way_ repository's continuous integration workflow.

--- a/book/website/community-handbook/style/style-writing-markdown.md
+++ b/book/website/community-handbook/style/style-writing-markdown.md
@@ -60,6 +60,7 @@ Note, that the formatting will be retained, so we can split each sentence to a n
 > I do not like green eggs and ham i do not like them sam i am
 ```
 
+(ch-style-writing-markdown-latin)=
 ## Avoid latin abbreviation
 
 Please do not use Latin abbreviations.

--- a/book/website/community-handbook/style/style-writing-markdown.md
+++ b/book/website/community-handbook/style/style-writing-markdown.md
@@ -88,8 +88,6 @@ If that is not possible, use an alternative such as ‘meaning’ or ‘that is�
 
 Any chapter containing a Latin abbreviation will fail the continuous integration (CI) workflow of the _The Turing Way_ GitHub repository from passing successfully, which is tested by this [Python script](https://github.com/the-turing-way/the-turing-way/blob/main/tests/no-bad-latin.py).
 
-*To avoid CI from failing, even in this chapter we have avoided to write those abbreviations and instead used an image to illustrate the above examples.*
-
 ## Tips
 
 ### Indentation


### PR DESCRIPTION
I quickly needed a reference elsewhere for why we should avoid latin abbreviations. Unfortunately the TTW references were at 3 different places and not cleanly linking to each other.
And it was mentioning CI as some kind of magic rather than just a tool that enforces the style rule we came up with.

So this PR: makes the references more accurarate, and rephrase/cleanup CI mentions.