### PR TITLE
Switch Book Dash notes to Framapad (#4206)

### DIFF
--- a/book/website/community-handbook/bookdash/bookdash-logistics.md
+++ b/book/website/community-handbook/bookdash/bookdash-logistics.md
@@ -36,7 +36,7 @@ We have created the following checklists, which are chronologically structured t
 - [ ] Send an email to the unselected attendees with feedback
 - [ ] Set up an email chain and a Slack channel to connect all members and share updates
 - [ ] Update presentation for introducing the project to the participants on day-1 of the Book Dash
-- [ ] Update shared HackMD for `pre-event calls<ch-template-bookdash-precall>`, {ref}`book dash event<ch-template-bookdash-notes>` and {ref}`feedback<ch-template-bookdash-feedback>`
+- [ ] Update shared Framapad for `pre-event calls<ch-template-bookdash-precall>`, {ref}`book dash event<ch-template-bookdash-notes>` and {ref}`feedback<ch-template-bookdash-feedback>`
 - [ ] Provide details on Code of Conduct, contribution guideline and ways to get involved in an ongoing discussion
 - [ ] Host the onboarding call one week before the event to share logistics and facilitate the drafting of SMART goals
 - [ ] Group participants into the proposed working groups as per their SMART goals from the onboarding call

--- a/book/website/community-handbook/templates.md
+++ b/book/website/community-handbook/templates.md
@@ -15,13 +15,13 @@ Illustration of a process of sketching. [Royalty free image from Many Pixels](ht
 (ch-template-bookdash)=
 ## Book Dash Events
 
-There are four MarkDown templates for the shared notes (HackMD), feedback and GitHub issue for organising and running _The Turing Way_ Book Dash events.
+There are four MarkDown templates for shared notes, feedback and GitHub issue for organising and running _The Turing Way_ Book Dash events.
 These templates can be reused and adapted for different events within and outside _The Turing Way_ community.
 
 - {ref}`HackMD Template for the Index Page<ch-template-bookdash-index>`
 - {ref}`HackMD Template for Pre-Event Calls<ch-template-bookdash-precall>`
 - {ref}`Issue Template for Planning Book Dashes<ch-template-bookdash-github>`
-- {ref}`HackMD Template for Shared Notes<ch-template-bookdash-notes>`
+- {ref}`Framapad Template for Shared Notes<ch-template-bookdash-notes>`
 - {ref}`HackMD Template for Post-Event Feedback<ch-template-bookdash-feedback>`
 
 (ch-template-coworking)=

--- a/book/website/community-handbook/templates/template-bookdash-notes.md
+++ b/book/website/community-handbook/templates/template-bookdash-notes.md
@@ -1,7 +1,7 @@
 (ch-template-bookdash-notes)=
-# HackMD Template for Shared Notes
+# Framapad Template for Shared Notes
 
-*This template can be used for shared note-taking and information exchange in HackMD during the book dash events.
+*This template can be used for shared note-taking and information exchange in Framapad during the book dash events.
 The access permission can be set so that the notes can be read by everyone and edited by any signed-in users.*
 
 ```
@@ -9,7 +9,7 @@ The access permission can be set so that the notes can be read by everyone and e
 
 ###### tags: `bookdash YYYY` `month` `event`
 
-==If you are new to HackMD, please see this short guide: [https://hackmd.io/\@turingway/hackmd-guide](https://hackmd.io/\@turingway/hackmd-guide)==
+==If you are new to Framapad, please see this short guide: [https://framapad.org/](https://framapad.org/)==
 
 :::info
 - **Location:** Online/in-person
@@ -37,7 +37,7 @@ All time provided in London Time (UTC+1). Please use this link to convert in you
 - GitHub resources and managing your contributions
 - An onboarding breakout room for new members and people who need refresher in GitHub
 - Feel free to propose breakout rooms if you have already identified your groups (topic, language, discussions)
-- Please use this HackMD as extensively as needed
+- Please use this Framapad as extensively as needed
 
 ## Groupings for breakout rooms based on the topics of interest:
 


### PR DESCRIPTION
### Summary

Fixes #4206

Replaced HackMD references with Framapad across Book Dash resources and recognised JohnnyRobs19 in the project’s contributor listings.

### List of changes proposed in this PR (pull-request)

* Updated Book Dash logistics checklist to reference a shared Framapad note.
* Updated templates index to link to the Framapad notes template.
* Revised the Book Dash shared notes template for Framapad.
* Added Jonathan Siew (GitHub: JohnnyRobs19) to the contributors listings.

### What should a reviewer concentrate their feedback on?

- [ ] Confirm Framapad references and links render correctly.
- [ ] Check that the contributor addition is accurate and follows project conventions.

### Acknowledging contributors

- [ ] The following people should be added to the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file: JohnnyRobs19
