### PR TITLE
Use title case in GitHub Gardening doc

### DIFF
--- a/book/website/community-handbook/github-gardening.md
+++ b/book/website/community-handbook/github-gardening.md
@@ -1,5 +1,5 @@
 (ch-gardening)=
-# GitHub gardening
+# GitHub Gardening
 
 Managing a open source community and maintaining its infrastructure, like [code repositories](#rr-vcs) and {term}`issue trackers <Issue Tracking>`, takes time an effort.
 In the free and open source community this work is often called maintenance.


### PR DESCRIPTION
Every other entry at this level in the Community Handbook uses title case, so this one stuck out a bit since it didn't
