### PR TITLE
Add documentation for appointing independent ombudsman (#3647)

### DIFF
--- a/docs/ombudsman.md
+++ b/docs/ombudsman.md
@@ -1,0 +1,46 @@
+Independent Ombudsman for Code of Conduct Concerns
+Purpose
+
+The independent ombudsman ensures that all code of conduct concerns are handled fairly, impartially, and transparently. The ombudsman must be external to the organisation to maintain independence and trust.
+
+Criteria for Selecting an Independent Ombudsman
+
+Must not be affiliated with the core leadership or decision-making team of the organization.
+
+Demonstrated experience in conflict resolution or handling community concerns.
+
+Known for impartiality and integrity.
+
+Able to commit sufficient time to review and investigate concerns.
+
+Appointment Process
+
+Leadership team identifies potential candidates based on the criteria above.
+
+Candidates are reviewed and shortlisted in consultation with the community or advisory board.
+
+Final appointment is confirmed by a majority agreement of the leadership team, ensuring independence.
+
+Term duration and renewal conditions are clearly documented.
+
+Scope of Authority and Responsibilities
+
+Receive code of conduct concerns from community members.
+
+Investigate complaints confidentially and impartially.
+
+Recommend actions or resolutions based on findings.
+
+Maintain records of all cases while protecting the privacy of involved parties.
+
+Provide periodic reports to the leadership team about trends or recurring issues, without disclosing personal information.
+
+Handling Code of Conduct Concerns
+
+Community members can submit concerns through designated channels (email, form, or platform).
+
+Ombudsman acknowledges receipt of the concern promptly.
+
+Investigation is carried out, ensuring fairness and transparency.
+
+Outcomes are communicated to the relevant parties, and any required actions are tracked until resolved.


### PR DESCRIPTION
This pull request adds documentation for issue #3647, which describes the process of identifying and appointing an independent ombudsman to handle Code of Conduct concerns.

Summary of changes:

Added a new file docs/ombudsman.md

Defined criteria for selecting an independent ombudsman

Documented the appointment process

Specified the ombudsman’s scope of authority and responsibilities

Described how the ombudsman will receive and investigate Code of Conduct concerns

Purpose:
To ensure fair, transparent, and independent handling of community conduct issues within The Turing Way project.
