### PR TITLE
Create template-new-chapter-announcement

### DIFF
--- a/book/website/community-handbook/templates/template-new-chapter-announcement
+++ b/book/website/community-handbook/templates/template-new-chapter-announcement
@@ -1,5 +1,6 @@
-Announcements for new chapter publications
+### Announcements for new chapter publications
 
-https://hackmd.io/0Vw_bZ9yQXuZtrLBxFUvvA
-https://hackmd.io/zCwKCGn6TYCXAOARRN1rXA
-https://hackmd.io/KPSQxvWoTp2CSy5Vz4rYqw
+This markdown template in HackMD provides information and examples to make announcements for new chapters in _The Turing Way handbook_, to be shared in our Slack, the newsletter, and social channels.
+
+* [Template for New chapter](https://hackmd.io/KPSQxvWoTp2CSy5Vz4rYqw)
+


### PR DESCRIPTION
Adding templates for new chapters announcement


### Summary

Updating community handbook templates with New Chapter announcements for Slack, socials, and newsletter

Fixes #4105 (https://github.com/the-turing-way/the-turing-way/issues/4105)


