### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ There are many ways to get in touch with _The Turing Way_ team!
 - [Slack Channel](https://join.slack.com/t/theturingway/shared_invite/zt-2v7euwuo7-BYstHdKuTNd1ce0puDtBxA)
   - For structured discussion and sustained engagement with the community members.
   - We will also provide notifications on upcoming events and share useful resources on Slack.
-- Contact the Research Community Manager and other members of _The Turing Way_ project delivery team by emailing [theturingway@gmail.com](mailto:theturingway@gmail.com).
+- Contact the Research Community Management working group and the Steering group by emailing [theturingway@gmail.com](mailto:theturingway@gmail.com).
 
 ### Receiving Updates
 


### PR DESCRIPTION
Replaced the Turing.ac.uk email with theturingway@gmail.com
