### PR TITLE
Provide Green CI and feedback when not building the book for all-contributors PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,6 @@ defaults:
   run:
     shell: bash
 
-permissions:
-  issues: write
-  pull-requests: write
-
 jobs:
   build-jb:
     name: Build
@@ -26,6 +22,9 @@ jobs:
       fail-fast: false # Don't cancel all jobs if one fails
 
     runs-on: ${{ matrix.os }}
+    permissions:
+      issues: write
+      pull-requests: write
 
     steps:
       - name: Extract the PR number from the ref


### PR DESCRIPTION
<!--
Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
-->
### Summary

- **The problem:** We don't want to build the book for all-contributors bots, but we want to require the build to pass for other PRs. Filtering for this behaviour is difficult using default GitHub Actions behaviour.

### List of changes proposed in this PR (pull-request)

<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

* The original `if` statement is moved from the build job-level, to all the original steps in the job
* Add new steps:
  * Extract the number of the PR
  * Post a comment on the PR explaining what has happened, why, and what the human reviewer should check.

### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

- [ ] Everything looks ok?

### Acknowledging contributors

<!-- Please select the correct box -->

- [x] All contributors to this pull request are already named in the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
