### PR TITLE
Revise glossary term referencing syntax

### DIFF
--- a/book/website/community-handbook/style/style-glossary.md
+++ b/book/website/community-handbook/style/style-glossary.md
@@ -29,6 +29,6 @@ Authors
 
 ```
 
-To reference terms in your glossary, use the syntax ```[{term}`def<Term>`]```.
-
-For example, to link the term 'Authors' to its definition in the glossary file, please use the syntax ```[{term}`def<Authors>`]``` next to where this term appears, which should render online like this: "*Authors [{term}`def<Authors>`] has been referenced here.*"
+To reference terms in your glossary, use the syntax ```{term}`Term```.
+For example, to link the term 'Authors' to its definition in the glossary file, please use the syntax ```{term}`Authors``` which should render online like this: "*{term}`Authors` has been referenced here.*"
+If you want to use custom text for the link, use the syntax ```{term}`custom text <Term>```. For example, ```{term}`author list <Authors>```` would render as "author list".


### PR DESCRIPTION
Summary
<!-- Describe the problem you're trying to fix in this pull request. Please reference any related issue and use fixes/close to automatically close them, if pertinent. For example: "Fixes #58", or "Addresses (but does not close) #238". -->
Fixes #4398 

Simplifies the glossary reference syntax as requested in the issue to make it easier to write and more accessible.

List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
Updated glossary reference syntax from [{term}\def<Term>`]to{term}`Term``

Removed complex def<...> wrapper and square brackets

Added example for custom text usage: {term}\custom text <Term>``

Updated documentation in community handbook style guide

What should a reviewer concentrate their feedback on?
<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
The new syntax examples are clear and correct

The custom text usage example is helpful

Everything looks ok?

Acknowledging contributors
<!-- Please select the correct box -->
All contributors to this pull request are already named in the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file.

The following people should be added to the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->

Note: Check the first box since you're already a contributor. Only check the second box if you're a new contributor who isn't already in the README.