### PR TITLE
Add embedding figures section to style-figures.md

### DIFF
--- a/book/website/community-handbook/style/style-figures.md
+++ b/book/website/community-handbook/style/style-figures.md
@@ -118,6 +118,15 @@ for more on multi-line strings in yaml see: [Demystifying YAML Multiline Strings
 After a figure is added in a chapter, it can be referenced using its label.
 For example, we can reference the figure above like `[](#first-pull-request)`, which renders as [](#first-pull-request).
 
+## Embedding a Figure from Another Chapter
+
+You can embed a figure that already exists elsewhere in the book using the `{embed}` directive.
+This allows you to reuse an existing figure without copying or duplicating image metadata.
+
+```{embed} ../../../figures/first-pull-request.*
+:height: 400px
+```
+
 (ch-style-figures-advanced)=
 ## Advanced features and "gotchas"
 


### PR DESCRIPTION
Added instructions for embedding figures from other chapters using the {embed} directive.

### Summary

This PR adds an example to the “Using Figures” style guide that demonstrates how to embed an existing figure from another chapter using the `{embed}` directive.

Fixes #4463

### List of changes proposed in this PR

* Added a new section titled **“Embedding a Figure from Another Chapter”**.
* Included a working example using the `{embed}` directive.
* Placed the new section between “Cross-Referencing Figures” and “Advanced features”.

### What should a reviewer concentrate their feedback on?

- [ ] Is the placement of the new section correct within the style guide?
- [ ] Does the example clearly illustrate how to use the `{embed}` directive?
- [ ] Any wording improvements needed?

### Acknowledging contributors

- [x] All contributors to this pull request are already named in the table of contributors.
