### PR TITLE
[DOC] Add example of embedding a figure using the embed directive

### DIFF
--- a/book/website/community-handbook/style/style-figures.md
+++ b/book/website/community-handbook/style/style-figures.md
@@ -60,14 +60,29 @@ In particular it is important to describe the licence under which the image is r
 
 For example, a caption might say:
 
-> Making your first pull request on GitHub.
-> _The Turing Way_ project illustration by Scriberia.
-> Used under a CC-BY 4.0 licence.
+> Making your first pull request on GitHub.  
+> _The Turing Way_ project illustration by Scriberia.  
+> Used under a CC-BY 4.0 licence.  
 > DOI: [10.5281/zenodo.3332807](https://doi.org/10.5281/zenodo.3332807).
 
 The syntax for this image is as follows, and the way it appears in the book is below the code snippet.
 
-````
+````markdown
+```{figure} ../../../figures/first-pull-request.*
+---
+height: 400px
+label: first-pull-request
+alt: >
+  Cartoon-like sketch of two persons sitting across from each other working on their laptops.
+  A straight arrow on the top indicates the main branch of the repository that they are working on,
+  a pull request is shown by a branch coming out of the main arrow labelled as Clone,
+  followed by a Pull Request with the changes that the first person made in the branch,
+  and the final step labelled as Approved that indicates approval of the changes by the second person.
+  This arrow then merges back to the main arrow/repository.
+---
+Making your first pull request on GitHub.
+_The Turing Way_ project illustration by Scriberia. Used under a CC-BY 4.0 licence. DOI: [10.5281/zenodo.3332807](https://doi.org/10.5281/zenodo.3332807).
+
 ```{figure} ../../../figures/first-pull-request.*
 ---
 height: 400px
@@ -83,40 +98,37 @@ alt: >
 Making your first pull request on GitHub.
 _The Turing Way_ project illustration by Scriberia. Used under a CC-BY 4.0 licence. DOI: [10.5281/zenodo.3332807](https://doi.org/10.5281/zenodo.3332807).
 ```
-````
-
-```{figure} ../../../figures/first-pull-request.*
----
-height: 400px
-label: first-pull-request
-alt: >
-  Cartoon-like sketch of two persons sitting across from each other working on their laptops.
-  A straight arrow on the top indicates the main branch of the repository that they are working on,
-  a pull request is shown by a branch coming out of the main arrow labelled as Clone,
-  followed by a Pull Request with the changes that the first person made in the branch,
-  and the final step labelled as Approved that indicates approval of the changes by the second person.
-  This arrow then merges back to the main arrow/repository.
----
-Making your first pull request on GitHub.
-_The Turing Way_ project illustration by Scriberia. Used under a CC-BY 4.0 licence. DOI: [10.5281/zenodo.3332807](https://doi.org/10.5281/zenodo.3332807).
-```
-
-Please make sure that the link to the source is the {term}`digital object identifier <Digital Object Identifier>` not the Zenodo record.
-Also ensure that you have created a link to the source using {term}`Markdown` link formatting: `[text](url)`.
-
-Figure information with the block delimited by `---` makes use of [yaml](https://yaml.org/spec/1.2.2/) syntax.
-Some characters (such as ':') have special meaning in YAML and using they may create unexpected results.
-This comes up quite often in longer blocks of text, such as the alt text tag.
-Using the syntax demonstrated above, `alt: >`, means you can have multi-line outputs and only need to 
-escape `|` and `>` to get those literal characters in the final output.
-You escape a character by prepending it with a backslash for example, `\|` and `\>`.
-for more on multi-line strings in yaml see: [Demystifying YAML Multiline Strings: An In-Depth Guide](https://thelinuxcode.com/yaml-multiline-strings/).
 
 (ch-style-figures-cross-referencing)=
 ## Cross-Referencing Figures in Other Chapters
 
 After a figure is added in a chapter, it can be referenced using its label.
 For example, we can reference the figure above like `[](#first-pull-request)`, which renders as [](#first-pull-request).
+
+(ch-style-figures-embedding)=
+## Embedding Figures from Other Chapters
+
+In addition to cross-referencing, you can also **embed** a figure that already exists elsewhere in the book.  
+Embedding allows you to reuse a figure — including its caption — without duplicating the image file or rewriting its code.
+
+The `{embed}` directive pulls content (like figures, tables, or sections) directly from another Markdown file.  
+If the original figure changes, all embedded copies update automatically.
+
+Here’s an example of embedding a figure from another page:
+
+```{embed} ../../community-handbook/acknowledging-contributors.md#theturingway-acknowledgement
+:align: center
+:width: 100%
+```
+
+In this example:
+- `../../community-handbook/acknowledging-contributors.md` is the **relative path** to the file containing the original figure.
+- `#theturingway-acknowledgement` is the **label** of that figure (defined in the original chapter).
+- Optional fields such as `:align:` and `:width:` adjust the display on the page.
+
+Embedding is especially helpful when the same figure is used across multiple chapters — for example, when a single illustration appears in both the *Community Handbook* and *Style Guide*.
+
+> 💡 For more details on the `{embed}` directive, see the [MyST documentation](https://mystmd.org/guide/embed#docs-embed).
 
 (ch-style-figures-advanced)=
 ## Advanced features and "gotchas"
@@ -134,3 +146,4 @@ We've noticed a couple of "gotchas" from contributors to _The Turing Way_ and we
 * You cannot have line breaks in the alt text, but you can have it in the caption.
 * Both `:` and `"` have syntactic meaning for Sphinx.
   That means it is important that you do not use these characters in your alt text.
+```


### PR DESCRIPTION
### Summary
This PR adds an example of using the `{embed}` directive in the *Style Guide* page on “Using Figures”.
It demonstrates how to reuse a figure from another chapter without duplicating the image file.

### What was done
- Added a new section titled “Embedding Figures from Other Chapters”.
- Included a MyST `{embed}` directive example.
- Linked to the official MyST documentation for reference.

### Related Issue
Fixes #4463
