### PR TITLE
Moved glossary terms to main glossary (Issue #4495)

### DIFF
--- a/book/website/reproducible-research/testing/testing-resources.md
+++ b/book/website/reproducible-research/testing/testing-resources.md
@@ -65,34 +65,10 @@ Try reading the chapter on reproducible computational environments and then the 
 
 ### Definitions/glossary
 
-- **Acceptance test:** A test that the program meets the project's fundamental requirements.
+<!-- Glossary terms moved to the main Glossary (Issue #4495) -->
 
-- **Code coverage:** A measure which describes how much of the source code is exercised by the test suite.
+## Materials used: glossary
 
-- **End to end test:** A test that runs the program from beginning to end and verifies that the output is correct.
+- [Netherlands eScience centre](https://guide.esciencecenter.nl/#/best_practices/testing) **Creative Commons Attribution 4.0 International License**
 
-- **Integration test:** A test where units of code are combined and run, and the output is verified to check the units have been correctly integrated.
-
-- **Mocking:** Replace a real object with a pretend one to use when running tests.
-
-- **Regression test:** Comparing the result of a test before and after the code has been altered. If the output has changed a problem has been introduced somewhere in the program, and an error is thrown.
-
-- **Runtime test:** Tests embedded within the program which are run as part of it.
-
-- **Smoke test:** Very brief initial checks that ensure the basic requirements needed to run the project hold.
-
-- **Stochastic code:** Code which, while correct, does not always output the same result. For example a program that outputs ten random numbers will generate a different result each time, despite being correct.
-
-- **System test:** See "end to end test".
-
-- **Test driven development:** A process of code development where unit tests are written before the units themselves.
-
-- **Test stub:** Fake implementations of parts of code which are used in testing to remove dependences.
-
-- **Test suite:** The tests that have been written for a project.
-
-- **Testing framework:** Tools that make writing and running tests less labour intensive.
-
-- **Unit:** A small piece of code that does one simple thing. It usually has one or a few inputs and usually a single output.
-
-- **Unit test:** A test that checks the behaviour of a unit.
+<!-- Glossary terms moved to the main Glossary (Issue #4495) -->


### PR DESCRIPTION
This pull request moves the glossary terms from the testing chapter into the main glossary as requested in Issue #4495.
The testing chapter had many definitions that were already covered in the main glossary, so I removed the duplicates and kept only the relevant content.

Fixes #4495