### PR TITLE
Fix broken video embeds in Collab Cafe handbook page (#4512)

### DIFF
--- a/book/website/community-handbook/community-calls/community-calls-collabcafe.md
+++ b/book/website/community-handbook/community-calls/community-calls-collabcafe.md
@@ -59,8 +59,7 @@ We have a template for the {ref}`Collaboration Cafes<ch-template-coworking-colla
 
 You can watch this video to see Kirstie and Malvika plan the structure and format of Collaboration Café.
 
-::: {iframe} https://www.youtube.com/embed/XUw5kpypeo8
-:width: 100%
+:::{youtube} XUw5kpypeo8
 :::
 
 
@@ -99,8 +98,7 @@ _The Turing Way_ community has adhered to a cadence of un-enforced and enforced 
 We have posted a few videos from our Collaboration Cafés on YouTube.
 Watch the video to see how Kirstie hosted the calls when it was first launched.
 
-::: {iframe} https://www.youtube.com/embed/I0z7OEbBzes
-:width: 100%
+:::{youtube} I0z7OEbBzes
 :::
 
 #### During the Call

--- a/book/website/community-handbook/style/consistency/consistency-formatting.md
+++ b/book/website/community-handbook/style/consistency/consistency-formatting.md
@@ -52,8 +52,7 @@ Please note that if `HTML` is the only option for you to format your text the wa
 For example, [superscripts and subscripts](https://support.squarespace.com/hc/en-us/articles/206543587-Markdown-cheat-sheet#toc-superscript-and-subscript) can be written in `HTML` because they always appear as intended.
 
 #### Demo
-::: {iframe} https://www.youtube.com/embed/tv0HlVgxDdI
-:width: 100%
+:::{youtube} tv0HlVgxDdI
 :::
 
 #### Writing Checklists
@@ -93,8 +92,7 @@ A list of such files can be found in [this issue](https://github.com/the-turing-
 
 #### Demo
 
-::: {iframe} https://www.youtube.com/embed/qq9QCrykdbw
-:width: 100%
+:::{youtube} qq9QCrykdbw
 :::
 
 (ch-consistency-formatting-hr-labels)=
@@ -108,8 +106,7 @@ This helps make _The Turing Way_ more navigable and accessible.
 
 #### Demo
 
-::: {iframe} https://www.youtube.com/embed/ikcjxjklLVg
-:width: 100%
+:::{youtube} ikcjxjklLVg
 :::
 
 (ch-consistency-formatting-hr-images)=
@@ -138,8 +135,7 @@ You should always check how your image looks in the Netlify preview of the book 
 
 #### Demo
 
-::: {iframe} https://www.youtube.com/embed/upBiKLR_A5E
-:width: 100%
+:::{youtube} upBiKLR_A5E
 :::
 
 (ch-consistency-formatting-sr)=
@@ -202,6 +198,5 @@ For example, because some of the headers in this chapter make up a checklist - t
 
 #### Demo
 
-::: {iframe} https://www.youtube.com/embed/ET_LI5dwP9M
-:width: 100%
+:::{youtube} ET_LI5dwP9M
 :::

--- a/book/website/community-handbook/style/consistency/consistency-language.md
+++ b/book/website/community-handbook/style/consistency/consistency-language.md
@@ -26,8 +26,7 @@ One rule of thumb to consider is that if a sentence needs to be read more than o
 
 #### Demo
 
-::: {iframe} https://www.youtube.com/embed/Prv23kGekVY
-:width: 100%
+:::{youtube} Prv23kGekVY
 :::
 
 (ch-consistency-language-hr-language)=

--- a/book/website/community-handbook/style/consistency/consistency-structure.md
+++ b/book/website/community-handbook/style/consistency/consistency-structure.md
@@ -77,8 +77,7 @@ The manually written table of contents is unnecessary as Jupyter Book auto-gener
 
 #### Demo
 
-::: {iframe} https://www.youtube.com/embed/Prv23kGekVY
-:width: 100%
+:::{youtube} Prv23kGekVY
 :::
 
 

--- a/book/website/community-handbook/style/style-videos.md
+++ b/book/website/community-handbook/style/style-videos.md
@@ -3,27 +3,21 @@
 
 ## Hosted videos
 
-If your video is hosted on a platform like YouTube or Vimeo you can use the [`iframe` directive](https://mystmd.org/guide/figures#youtube-videos) to embed it.
+If your video is hosted on a platform like YouTube or Vimeo you can use the [`youtube` directive](https://mystmd.org/guide/figures#youtube-videos) to embed it.
 For example,
 
 ````
-::: {iframe} https://www.youtube.com/embed/MdOS6tPq8fc
-:width: 100%
-:align: center
+:::{youtube} MdOS6tPq8fc
 :label: example-video
-How to build a Jupyter Book!
 :::
 ````
 
 renders as,
 
-::: {iframe} https://www.youtube.com/embed/MdOS6tPq8fc
-:width: 100%
-:align: center
+:::{youtube} MdOS6tPq8fc
 :label: example-video
-How to build a Jupyter Book!
 :::
 
 and can be referenced with `[](#example-video)`, which when rendered will appear as: [](#example-video).
 
-For youtube, the link formatting you need to use is `https://www.youtube.com/embed/` followed by the code at the end of the video URL (`MdOS6tPq8fc` for the above video example).
+For youtube, the link formatting you need to use is just the code at the end of the video URL (`MdOS6tPq8fc` for the above video example).

--- a/book/website/ethical-research/data-hazards/dh-intro.md
+++ b/book/website/ethical-research/data-hazards/dh-intro.md
@@ -8,8 +8,7 @@ They exist to facilitate interdisciplinary discussions and self-reflection about
 Ultimately, the project aims to help data practitioners to identify and mitigate these risks.
 You can watch a short animation explaining the project below:
 
-::: {iframe} https://www.youtube-nocookie.com/embed/26fNnar4JvY?controls=0
-:width: 100%
+:::{youtube} 26fNnar4JvY
 :::
 
 (er-datahazardsintro-datahazardslabels)=

--- a/book/website/foreword/governance.md
+++ b/book/website/foreword/governance.md
@@ -36,8 +36,7 @@ Each level of decision-making should inform and influence each other, both apply
 Below, we describe these three levels of decision-making in the context of _The Turing Way_, inputs for which were invited from open discussions with our community members ([follow Miro board for details](https://miro.com/app/board/uXjVIe_VQAQ=/?share_link_id=593022744253)).
 This model was presented at a Community Forum in February 2024, a recording of which is shared below.
 
-::: {iframe} https://www.youtube.com/embed/WzzfaSQQL1w?si=76j7P-MFJbfGWgLQ
-:width: 100%
+:::{youtube} WzzfaSQQL1w
 :::
 
 _This is a recording from the first public Community Forum hosted in February 2024._

--- a/book/website/project-design/data-security/sdp/types.md
+++ b/book/website/project-design/data-security/sdp/types.md
@@ -45,6 +45,5 @@ The following sub-chapters give an overview of the types of sensitive data and m
 
 Here is a short video introducing sensitive data by ELIXIR-UK.
 
-::: {iframe} https://www.youtube.com/embed/2PXFu33IGVU
-:width: 100%
+:::{youtube} 2PXFu33IGVU
 :::

--- a/book/website/project-design/missing-data/missing-data-checklist-resources.md
+++ b/book/website/project-design/missing-data/missing-data-checklist-resources.md
@@ -78,17 +78,14 @@ Alternatively, if you want to make your research project and data analysis pipel
    - [missforest](https://cran.r-project.org/web/packages/missForest/index.html)
 - The Turing-Roche partnership has some resources on structured missingness:
    - See *#ExplainToMe: The Problem of Structured Missing Data* for a great animated overview
-    ::: {iframe} https://www.youtube.com/embed/nlevyS1GLlQ?si=4exk2HIvU1-5y004
-    :width: 100%
+    :::{youtube} nlevyS1GLlQ
     :::
    - Papers on structured missingness (that were cited previously): {cite:ps}`Mitra2023structuredmissingness` and {cite:ps}`Jackson2023structuredmissingness`
    - For more in-depth recordings from the Turing-Roche Knowledge Series see: 
      - *Modern Topics on Missing Data*, which also provides a brief overview of missing data:
-        ::: {iframe} https://www.youtube.com/embed/Cbj3X5wBeEg?si=ILs6NMeNX1FPkqnW
-        :width: 100%
+        :::{youtube} Cbj3X5wBeEg
         :::
      - *Structured Missingness Challenges in Data Integration*: 
-        ::: {iframe} https://www.youtube.com/embed/lnLd7LLkmDY?si=OjFgZZhgqCBoNLA1
-        :width: 100%
+        :::{youtube} lnLd7LLkmDY
         :::
 

--- a/book/website/reproducible-research/open/open-access.md
+++ b/book/website/reproducible-research/open/open-access.md
@@ -44,13 +44,12 @@ The number of these journals is still increasing rapidly, with 17,000 listed in 
 
 Watch this talk by Vicky Hellon on "Brief History of scientific publishing, and where do we go from here?", where she provides an overview of how different models of scientific publication look like, and how we can take an informed approach to Open Access.
 
-::: {iframe} https://www.youtube.com/embed/Mycp7SzBWB0
+:::{youtube} Mycp7SzBWB0
 :align: center
-:width: 100%
+:::
 
 History of Scientific Publishing - Where do we go from here?
 Slides: https://doi.org/10.5281/zenodo.6516871
-:::
 
 
 (rr-open-access-gold-publishing)=


### PR DESCRIPTION
### Checklist

- [x] I agree to follow _The Turing Way_'s [code of conduct](https://book.the-turing-way.org/community-handbook/coc/)
- [x] I have read the [contribution guide](https://book.the-turing-way.org/community-handbook/contributing/)
- [x] I have read the [style guide](https://book.the-turing-way.org/community-handbook/style/)

---

### Summary

This pull request fixes broken video embeds on the **Collab Cafe handbook page**.  
Some embedded videos were not rendering correctly due to outdated or incorrect embed URLs. This PR updates those embeds so the videos display and play as expected.

Fixes #4512

---

### List of changes proposed in this PR

- [x] Updated broken video embed URLs on the Collab Cafe handbook page
- [x] Verified that all embedded videos render correctly after the fix
- [x] Ensured formatting remains consistent with the handbook style guide

---

### What should a reviewer concentrate their feedback on?

- [ ] Do the videos render correctly on the handbook page?
- [ ] Are the updated embed links correct and consistent?
- [ ] Any formatting or style issues introduced by the changes?

---

### Acknowledging contributors

- [x] All contributors to this pull request are already named in the  
  [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file.
