### PR TITLE
Fix broken video embeds in Collaboration Cafe page 

### DIFF
--- a/book/website/community-handbook/community-calls/community-calls-collabcafe.md
+++ b/book/website/community-handbook/community-calls/community-calls-collabcafe.md
@@ -57,7 +57,7 @@ We have a template for the {ref}`Collaboration Cafes<ch-template-coworking-colla
 
 You can watch this video to see Kirstie and Malvika plan the structure and format of Collaboration Café.
 
-::: {iframe} https://www.youtube.com/embed/XUw5kpypeo8
+:::: {iframe} https://www.youtube.com/embed/XUw5kpypeo8
 :width: 100%
 :::
 
@@ -97,7 +97,7 @@ _The Turing Way_ community has adhered to a cadence of un-enforced and enforced 
 We have posted a few videos from our Collaboration Cafés on YouTube.
 Watch the video to see how Kirstie hosted the calls when it was first launched.
 
-::: {iframe} https://www.youtube.com/embed/I0z7OEbBzes
+:::: {iframe} https://www.youtube.com/embed/I0z7OEbBzes
 :width: 100%
 :::
 


### PR DESCRIPTION
### Checklist

- [x] I agree to follow _The Turing Way_'s [code of conduct](https://book.the-turing-way.org/community-handbook/coc/)
- [x] I have read the [contribution guide](https://book.the-turing-way.org/community-handbook/contributing/)
- [x] I have read the [style guide](https://book.the-turing-way.org/community-handbook/style/)

### Summary

Fixes #4512

Fixed broken video embeds on the Collaboration Cafe page by correcting the iframe directive syntax.

### List of changes proposed in this PR (pull-request)

- Changed `:::` to `::::` for opening the iframe directive on both video embeds
- This matches the correct syntax used throughout the rest of the book

### What should a reviewer concentrate their feedback on?

- [x] Verify that the video embeds now display correctly on the rendered page
- [x] Everything looks ok?

### Acknowledging contributors

- [x] All contributors to this pull request are already named in the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file.
