### PR TITLE
Fix Diátaxis attribution, anchor, cross-reference and typo in code-documentation-code.md

### DIFF
--- a/book/website/reproducible-research/code-documentation/code-documentation-code.md
+++ b/book/website/reproducible-research/code-documentation/code-documentation-code.md
@@ -12,7 +12,7 @@ such as explanations about how to start using the software, or examples of how t
 What to document will be different for each software, and how to document it will be different for each audience.   
 Below, there is guidance on how writing extended software documentation can be approached.
 
-(divio-documentation-system)=
+(diataxis-documentation-framework)=
 ### Diataxis Documentation Framework
 When extended documentation is necessary, common questions are: What to document? and 
 How to organise documentation concisely?
@@ -35,7 +35,7 @@ A reference guide for $S$ should describe what inputs it expects, what outputs i
 
 Another way to think about software documentation is to distinguish between the documentation for the end user of the software, 
 and the documentation oriented to describe the insides of the software to other developers. 
-This approach for organising documentation is simpler than [Divios Documentation System](#divio-documentation-system), 
+This approach for organising documentation is simpler than [Diátaxis Documentation Framework](#diataxis-documentation-framework), 
 but it does not offer further guidance about how to distinguish which aspects of software documentation are relevant for an end user and which are relevant for a developer. 
 It is up to the developer's experience to decide what content is relevant and for whom.
 The table below offers some examples on what might be included as user and developer documentation.
@@ -43,7 +43,7 @@ The table below offers some examples on what might be included as user and devel
 | User Documentation | Developer Documentation |
 |----------|----------|
 | Installation instructions  | Development setup  |
-| Default settings  | How to run tests  |s
+| Default settings  | How to run tests  |
 | Tutorials | Development roadmap |
 
 > Regardless of which approach is used to document software. The bottom line is 'some documentation is better than no documentation'


### PR DESCRIPTION
### Checklist

- [x] I agree to follow _The Turing Way_'s [code of conduct](https://book.the-turing-way.org/community-handbook/coc/)
- [x] I have read the [contribution guide](https://book.the-turing-way.org/community-handbook/contributing/)
- [x] I have read the [style guide](https://book.the-turing-way.org/community-handbook/style/)

### Summary

Fixes #4343

Updated anchor, cross-reference link and removed a stray typo, as described in issue #4343. The main paragraph text had already been corrected in a previous edit.

### List of changes proposed in this PR (pull-request)

* Updated anchor from `(divio-documentation-system)=` to `(diataxis-documentation-framework)=`
* Updated cross-reference link text and target from "Divios Documentation System" to "Diátaxis Documentation Framework"
* Removed stray `s` character after table row

### What should a reviewer concentrate their feedback on?

- [x] Everything looks ok?

### Acknowledging contributors

- [x] All contributors to this pull request are already named in the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->