### PR TITLE
docs(testing): move chapter glossary into book-level Glossary (#4495)

### DIFF
--- a/book/website/reproducible-research/testing/testing-resources.md
+++ b/book/website/reproducible-research/testing/testing-resources.md
@@ -65,34 +65,4 @@ Try reading the chapter on reproducible computational environments and then the 
 
 ### Definitions/glossary
 
-- **Acceptance test:** A test that the program meets the project's fundamental requirements.
-
-- **Code coverage:** A measure which describes how much of the source code is exercised by the test suite.
-
-- **End to end test:** A test that runs the program from beginning to end and verifies that the output is correct.
-
-- **Integration test:** A test where units of code are combined and run, and the output is verified to check the units have been correctly integrated.
-
-- **Mocking:** Replace a real object with a pretend one to use when running tests.
-
-- **Regression test:** Comparing the result of a test before and after the code has been altered. If the output has changed a problem has been introduced somewhere in the program, and an error is thrown.
-
-- **Runtime test:** Tests embedded within the program which are run as part of it.
-
-- **Smoke test:** Very brief initial checks that ensure the basic requirements needed to run the project hold.
-
-- **Stochastic code:** Code which, while correct, does not always output the same result. For example a program that outputs ten random numbers will generate a different result each time, despite being correct.
-
-- **System test:** See "end to end test".
-
-- **Test driven development:** A process of code development where unit tests are written before the units themselves.
-
-- **Test stub:** Fake implementations of parts of code which are used in testing to remove dependences.
-
-- **Test suite:** The tests that have been written for a project.
-
-- **Testing framework:** Tools that make writing and running tests less labour intensive.
-
-- **Unit:** A small piece of code that does one simple thing. It usually has one or a few inputs and usually a single output.
-
-- **Unit test:** A test that checks the behaviour of a unit.
+The testing-related terms previously listed here have been moved to the book-level {ref}`aw-glossary`, where they live alongside the rest of _The Turing Way_'s vocabulary. See the entries for {term}`acceptance testing`, {term}`code coverage`, {term}`end to end test`, {term}`integration testing`, {term}`mocking`, {term}`regression test`, {term}`runtime test`, {term}`smoke testing`, {term}`stochastic code`, {term}`system testing`, {term}`test driven development`, {term}`test stub`, {term}`test suite`, {term}`testing framework`, {term}`unit`, and {term}`unit testing`.


### PR DESCRIPTION
> **Dear maintainer** — this PR has a permanent home with methodology + [opt-out](https://github.com/adv0r/tokens-for-good/blob/main/MAINTAINER_REMOVAL.md) at [tokens-for-good](https://github.com/adv0r/tokens-for-good). A one-line "no thanks" → auto-close + blacklist. Sorry for the notification this edit caused.
>
> ---

AI-assisted via Cursor (Claude Opus 4.7).
Personal token-burn initiative: contributing OSS work using leftover Cursor credits before subscription renewal.

Closes #4495.

## What changed
The testing chapter (`book/website/reproducible-research/testing/testing-resources.md`) had a duplicated, local `Definitions/glossary` section. All 16 terms in that section are already defined in the book-level `{ref}aw-glossary` (`book/website/afterword/glossary.md`) — I verified each one is present (acceptance testing, code coverage, end to end test, integration testing, mocking, regression test, runtime test, smoke testing, stochastic code, system testing, test driven development, test stub, test suite, testing framework, unit, unit testing).

This PR:
- Removes the duplicated definitions block in `testing-resources.md`.
- Replaces it with a single sentence that points readers to the book-level glossary and uses ``{term}`` references for each term — exactly the linking pattern documented in the Style/Glossary chapter (`{term}\`acceptance testing\``).
- Keeps the `Materials used: glossary` attribution to the Netherlands eScience centre untouched.

I deliberately kept the scope minimal:
- I did **not** edit definitions in `afterword/glossary.md` (they already cover all the moved terms).
- I did **not** sweep the rest of the testing chapter to add `{term}` cross-references to every occurrence — happy to do that in a follow-up PR if a maintainer wants it; this PR focuses on the "move" step from the issue checklist.

## How verified
- `rg -i '^(acceptance|code coverage|...)' book/website/afterword/glossary.md` confirms every term exists in the book-level glossary.
- Diff is `+1 / -31` on a single file.
- `{term}` / `{ref}` syntax matches existing usage in `community-handbook/style/style-glossary.md` and other chapters that reference the glossary.

## Checklist from the issue
- [x] Move these terms to the book-level Glossary section _(already present — verified)_
- [x] Review the definitions _(spot-checked: the book-level entries are equivalent or richer than the local list; "system test" maps to "system testing" which already says "Also called end-to-end testing")_
- [ ] Use the term role where these terms appear in the book _(scoped out of this PR — see note above)_

Made with [Cursor](https://cursor.com)
