### PR TITLE
fix(refs): update broken Cow20 link to current Princeton handbook (#3812)

### DIFF
--- a/book/website/references.bib
+++ b/book/website/references.bib
@@ -457,8 +457,8 @@
   title = {Research Guides: Research Data Management at Princeton: File naming and structure},
   year = {2020},
   month = {Oct},
-  note = {Online; accessed 19. Nov. 2020},
-  url = {https://libguides.princeton.edu/c.php?g=102546&p=930626}
+  note = {Online; accessed 20. May 2026},
+  url = {https://researchdata.princeton.edu/research-lifecycle-guide}
 }
 
 @misc{Hodge2015Filenaming,


### PR DESCRIPTION
> **Dear maintainer** — this PR has a permanent home with methodology + [opt-out](https://github.com/adv0r/tokens-for-good/blob/main/MAINTAINER_REMOVAL.md) at [tokens-for-good](https://github.com/adv0r/tokens-for-good). A one-line "no thanks" → auto-close + blacklist. Sorry for the notification this edit caused.
>
> ---

AI-assisted via Cursor (Claude Opus 4.7).
Personal token-burn initiative by @adv0r: contributing OSS work using leftover
Cursor credits before the subscription cycle ends.

Closes #3812.

## What changed

The Princeton libguides URL for the file-naming guide referenced by `Cow20`
(`Cowles2019Filenaming`) has been retired and now returns HTTP 404:

- old: `https://libguides.princeton.edu/c.php?g=102546&p=930626` → 404
- new: `https://researchdata.princeton.edu/research-lifecycle-guide` → 200,
  Princeton Data Management Handbook, which contains the same *File
  Organization → File Naming* guidance (best-practice list, ISO 8601 example,
  versioning recommendations) previously published on libguides.

Minimal diff in `book/website/references.bib`: only the `url` and the
`accessed` date in `note` change. Author / title / year / month preserved so
the historical citation still resolves correctly.

## How verified

- `curl -I` on the old URL: HTTP 404
- WebFetch on the new URL: HTTP 200, page contains the *File Naming* section
  with the same ISO 8601 date-format guidance the original Cowles guide
  promoted (e.g. `YYYYMMDD_Image_Modification` examples)
- Same minimal-diff pattern used in PR #4624 (which fixed the sibling `Hod15`
  broken link via the same `references.bib` file)

## Notes

Same kind of low-risk citation fix as #4624 — pure `.bib` metadata update, no
prose changes.

Made with [Cursor](https://cursor.com)
