### PR TITLE
Added sections related to prompt engineering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,25 @@
 <a href="https://book.the-turing-way.org"><img src="book/figures/logo-detail-with-text.svg?raw=true)" width="180" align="Right" /></a>
 
+## Which repo to use
+
+**Use `stjude-biohackathon/the-turing-way` when:**
+- Building an AI agent that guides people through Turing Way content
+- Creating interactive experiences around Turing Way material
+- Developing tools that surface or navigate Turing Way chapters
+
+**Use `stjude/data-ai-learning-resources` when:**
+- Creating AI learning materials for St Jude staff
+- Drafting educational content about AI tools/methods
+- Building internal tutorials or training resources
+
+**Use `stjude/stjude-skills-internal` when:**
+- Writing AI prompts or Claude skills
+- Documenting prompt engineering patterns
+- Creating reusable AI tool configurations
+
 # _The Turing Way_
+
+
 
 >_This README.md file is also available in Chinese ([README-Chinese](README-translated/README-Chinese.md)), Dutch ([README-Dutch](README-translated/README-Dutch.md)), French ([README-French.md](README-translated/README-French.md)), German ([README-German.md](README-translated/README-German.md)), Indonesian ([README-Indonesian](README-translated/README-Indonesian.md)), Italian ([README-Italian](README-translated/README-Italian.md)), Korean ([README-Korean](README-translated/README-Korean.md)), Portuguese ([README-Portuguese](README-translated/README-Portuguese.md)), and Spanish ([README-Spanish](README-translated/README-Spanish.md)) (listed alphabetically)._
 

--- a/book/website/artificial-intelligence/artifical-intelligence.md
+++ b/book/website/artificial-intelligence/artifical-intelligence.md
@@ -1,0 +1,248 @@
+# Foundations of Artificial Intelligence
+
+## 1. Introduction
+
+Artificial Intelligence (AI) refers to the development of computer systems capable of performing tasks that typically require human intelligence. These tasks include reasoning, learning, problem-solving, understanding natural language, and perception.
+
+Over the past decade, AI has evolved rapidly due to improvements in computational power, data availability, and advances in machine learning algorithms. Today, AI is embedded in healthcare, finance, genomics, autonomous systems, and many other domains.
+
+---
+
+## 2. Core Concepts in AI
+
+### 2.1 Machine Learning (ML)
+
+Machine Learning is a subset of AI that focuses on enabling systems to learn from data without being explicitly programmed.
+
+Common types of machine learning include:
+- **Supervised Learning**: Learning from labeled data
+- **Unsupervised Learning**: Identifying patterns in unlabeled data
+- **Reinforcement Learning**: Learning via interactions and rewards
+
+---
+
+### 2.2 Deep Learning
+
+Deep Learning is a subset of ML that uses neural networks with multiple layers to model complex patterns.
+
+Applications include:
+- Image recognition
+- Speech processing
+- Genomic data analysis
+- Natural language processing (NLP)
+
+---
+
+### 2.3 Natural Language Processing (NLP)
+
+NLP focuses on enabling machines to understand, interpret, and generate human language.
+
+Key tasks:
+- Text classification
+- Named entity recognition
+- Language translation
+- Conversational AI
+
+---
+
+## 3. Prompt Engineering
+
+Prompt Engineering is the practice of designing effective inputs (prompts) to guide AI models, particularly large language models (LLMs), toward desired outputs.
+
+### 3.1 Key Principles
+
+- **Clarity**: Be explicit about the task
+- **Context**: Provide relevant background information
+- **Structure**: Define format and constraints
+- **Iteration**: Refine prompts based on results
+
+### 3.2 Example
+
+**Prompt:**
+
+#### Basic Prompt
+Summarize the following clinical report in 3 bullet points.
+
+#### Improved Prompt
+Summarize the following clinical genomics report in exactly 3 concise bullet points. Highlight:
+- key findings
+- detected mutations
+- clinical relevance
+
+#### Explanation
+
+The improved prompt is more effective because it:
+- Adds domain context (clinical genomics instead of generic report)
+- Specifies output format clearly (exactly 3 bullet points)
+- Defines what to focus on (findings, mutations, relevance)
+
+---
+
+### 3.3 Prompt Engineering Patterns
+
+#### 1. Instruction-Based Prompts
+Provide direct instructions.
+
+Example:
+Classify the following variant as benign, likely benign, VUS, or pathogenic.
+
+---
+
+#### 2. Few-Shot Learning
+
+Provide examples to guide the model.
+
+Example:
+Input: BRCA1 variant c.68_69del → Pathogenic  
+Input: TP53 variant c.215C>G → Likely Pathogenic  
+Input: [NEW VARIANT HERE] → ?
+
+---
+
+#### 3. Chain-of-Thought Prompts
+
+Encourage step-by-step reasoning.
+
+Example:
+Explain step-by-step how this genomic variant impacts protein function before classifying it.
+
+---
+
+#### 4. Role-Based Prompts
+
+Assign a role to the AI.
+
+
+Example:
+You are a clinical genomics expert. Review the following variant annotation and summarize its clinical significance.
+
+---
+
+### 3.4 Common Pitfalls
+
+- **Vague prompts**
+  - Example: "Summarize this" → unclear expectations
+
+- **Missing constraints**
+  - No format or length instructions
+
+- **Overloaded prompts**
+  - Too many tasks in a single request
+
+- **Lack of domain context**
+  - Leads to generic or incorrect responses
+
+---
+
+### 3.5 Best Practices
+
+- Be specific and structured  
+- Define output format clearly  
+- Use domain-specific language when needed  
+- Iterate and refine prompts based on outputs  
+- Validate results, especially in clinical or high-stakes domains  
+
+
+## 4. AI Assistants
+
+AI Assistants are systems designed to help users perform tasks through natural interaction.
+
+### 4.1 Capabilities
+
+- Answering questions
+- Drafting emails or documentation
+- Summarizing content
+- Assisting with coding and debugging
+
+### 4.2 Use Cases
+
+- Clinical workflow automation
+- QA documentation support
+- Data analysis assistance
+- Knowledge retrieval
+
+---
+
+## 5. AI Agents
+
+AI Agents extend beyond assistants by taking autonomous actions based on goals.
+
+### 5.1 Characteristics
+
+- Goal-oriented behavior
+- Ability to plan and execute tasks
+- Interaction with tools and systems
+- Memory and context awareness
+
+### 5.2 Types of Agents
+
+- **Reactive Agents**: Respond to immediate inputs
+- **Deliberative Agents**: Plan future actions
+- **Multi-Agent Systems**: Multiple agents collaborating
+
+---
+
+## 6. AI Skills and Tool Usage
+
+AI systems often rely on specialized “skills” or tools to extend their capabilities.
+
+Examples:
+- Database querying
+- Code execution
+- File processing
+- Workflow automation
+
+These skills enable AI systems to:
+- Perform complex workflows
+- Integrate with enterprise systems
+- Support decision-making processes
+
+---
+
+## 7. Evaluation and Limitations
+
+### 7.1 Evaluation Metrics
+
+- Accuracy
+- Precision and recall
+- Robustness
+- Interpretability
+
+### 7.2 Challenges
+
+- Data bias
+- Model hallucination
+- Lack of transparency
+- Privacy and security concerns
+
+---
+
+## 8. Ethical Considerations
+
+Responsible AI development requires adherence to principles such as:
+
+- **Fairness**: Avoiding bias
+- **Transparency**: Explaining decisions
+- **Accountability**: Assigning responsibility
+- **Privacy**: Protecting sensitive data
+
+These are especially critical in domains like healthcare and clinical genomics.
+
+---
+
+## 9. Future Directions
+
+Emerging trends in AI include:
+
+- Multi-modal AI (text, image, genomics integration)
+- Autonomous AI agents
+- AI-driven scientific discovery
+- Personalized AI systems
+
+---
+
+## 10. Conclusion
+
+Artificial Intelligence is transforming how we solve problems, analyze data, and deliver value across industries. Understanding foundational concepts such as machine learning, prompt engineering, AI assistants, and agents is essential for effectively leveraging AI in real-world applications.
+
+As AI continues to evolve, interdisciplinary collaboration and responsible deployment will be key to maximizing its benefits while minimizing risks.

--- a/book/website/artificial-intelligence/prompt-engineering/prompt-engineering-frameworks.md
+++ b/book/website/artificial-intelligence/prompt-engineering/prompt-engineering-frameworks.md
@@ -1,0 +1,119 @@
+# How to Write an Effective Prompt
+
+Writing an effective prompt can sometimes feel overwhelming because the user must think about context, task, constraints, audience, and output format all at once. A practical way to simplify the process is to use a repeatable structure.
+
+An effective prompt usually contains these elements:
+
+- **Role**: Who should the AI act as?
+- **Context**: What background information does the AI need?
+- **Task**: What exactly should the AI do?
+- **Audience**: Who will use the output?
+- **Constraints**: What should be included, excluded, or handled carefully?
+- **Evidence boundary**: What sources should the AI rely on?
+- **Output format**: How should the answer be presented?
+
+A strong prompt might look like this:
+
+```text
+Act as a clinical research methodologist.
+
+Context:
++We are reviewing a retrospective cohort study about treatment outcomes in pediatric oncology.
+
+Task:
++Summarize the study design and identify methodological strengths and limitations.
+
+Constraints:
++Do not make claims beyond the provided text. Separate confirmed findings from assumptions. Highlight possible confounders, bias, missing data concerns, and generalizability limits.
+
+Audience:
++Clinical researchers, physicians, and data analysts.
+
+Output:
++Use sections for Study Design, Population, Outcomes, Strengths, Limitations, Bias/Confounding, and Questions for Authors.
+```
+
+Good prompts are specific but not overloaded. They provide enough information for the AI to succeed while keeping the instruction focused.
+
+When writing prompts, consider these practices:
+
+- Define the AI's role clearly
+- Provide business, clinical, scientific, or technical context
+- State the exact task
+- Identify the intended audience
+- Mention what to include and exclude
+- Ask for a specific output format
+- Provide examples when consistency matters
+- Ask the model to identify assumptions
+- Ask for risks, limitations, and gaps
+- Require evidence boundaries when working with source material
+- Review and refine the result
+
+A weak prompt asks for a summary. A strong prompt asks for the right summary, for the right audience, using the right evidence, in the right format.
+
+
+## Prompt Engineering Frameworks
+
+Frameworks help make prompts repeatable. They are especially useful for teams because they reduce variation and improve consistency.
+
+### TAO Framework
+
+TAO stands for **Thought, Action, and Observation**. It is often used in agent-style AI workflows where the model analyzes a task, performs an action, observes the result, and continues toward a goal.
+
+In healthcare, research, software, and testing workflows, TAO can be adapted as follows:
+
+- **Thought**: Understand the problem, context, stakeholders, risks, assumptions, and evidence.
+- **Action**: Summarize, classify, compare, extract, generate, test, validate, or recommend.
+- **Observation**: Report findings, limitations, uncertainties, gaps, and next steps.
+
+Example:
+
+```text
+Use the TAO framework to review this clinical research abstract.
+
+Thought:
++Identify the research question, study population, intervention/exposure, outcomes, and assumptions.
+
+Action:
++Extract key methodological details and summarize the main findings.
+
+Observation:
++List limitations, missing information, potential sources of bias, and follow-up questions.
+```
+
+TAO is useful when the task involves investigation, not just generation. It can help professionals move from understanding a problem to producing an output and then evaluating whether anything is missing.
+
+### CO-STAR Framework
+
+CO-STAR is a prompt framework that stands for:
+
+- **C**: Context
+- **O**: Objective
+- **S**: Style
+- **T**: Tone
+- **A**: Audience
+- **R**: Response format
+
+Example:
+
+```text
+Context:
++We are preparing a patient-friendly explanation of genetic testing results for a hospital genetics clinic.
+
+Objective:
++Explain what the test can and cannot tell the patient, including limitations and the need for clinician interpretation.
+
+Style:
++Clear, structured, and accessible.
+
+Tone:
++Calm, respectful, and non-alarming.
+
+Audience:
++Patients and family members without medical training.
+
+Response format:
++Use short sections, plain language, and a final list of questions the patient may ask their clinician.
+```
+
+CO-STAR is useful because it forces the prompt writer to think beyond the task. It considers why the output is needed, who will use it, and how the answer should be shaped

--- a/book/website/artificial-intelligence/prompt-engineering/prompt-engineering.md
+++ b/book/website/artificial-intelligence/prompt-engineering/prompt-engineering.md
@@ -1,0 +1,130 @@
+# Chapter: Prompt Engineering for Healthcare, Research, and Technical Professionals
+
+## Introduction
+
+Artificial intelligence is becoming a practical partner across healthcare, biomedical research, clinical operations, public health, software engineering, data science, and quality assurance. Researchers use AI to summarize literature, design experiments, draft protocols, and explore hypotheses. Scientists use it to explain methods, compare datasets, and prepare technical reports. Doctors and healthcare professionals use it to summarize medical information, prepare patient-friendly explanations, review clinical documentation, and support administrative tasks. Software engineers and testers use it to generate code, review requirements, analyze defects, and design validation strategies.
+
+In all of these settings, the quality of the AI output depends heavily on the quality of the instruction given to it. That instruction is called a **prompt**.
+
+Prompt engineering is the practice of designing clear, structured, and purposeful instructions that guide an AI model toward a useful response. A well-written prompt helps the model understand the task, context, audience, constraints, expected output, and standard of evidence. In healthcare and research environments, this is especially important because vague prompts can lead to incomplete summaries, unsupported assumptions, misleading explanations, or outputs that are not appropriate for clinical, scientific, or regulatory use.
+
+In simple terms, prompt engineering is not just asking a question. It is the skill of communicating with AI in a way that improves accuracy, relevance, consistency, transparency, and usefulness.
+
+## What Is Prompt Engineering?
+
+Prompt engineering is the process of crafting inputs for an AI system so that it produces the desired output. A prompt may be a question, an instruction, a role assignment, a set of examples, a task description, a structured template, or a combination of these.
+
+For example, a basic prompt might be:
+
+```text
+Summarize this article.
+```
+
+A stronger prompt would be:
+
+```text
+Act as a biomedical research assistant. Summarize the attached article for a clinical research team. Include the study objective, population, methods, primary findings, limitations, and implications for future research. Do not add claims that are not supported by the article. Present the response using clear section headings.
+```
+
+The second prompt gives the AI a role, audience, source boundary, expected sections, and evidence constraint. Because of that, the response is more likely to be useful and safer for professional work.
+
+Prompt engineering matters because AI models do not truly know the user's intent unless enough guidance is provided. They generate responses based on the input they receive. Better input usually produces better output.
+
+## Why Prompt Engineering Matters?
+
+Healthcare, scientific research, and technical work all depend on precision. A vague instruction can produce an answer that sounds confident but misses key assumptions, limitations, or risks. Prompt engineering helps professionals use AI more reliably by making tasks explicit, repeatable, and reviewable.
+
+Prompt engineering can help with:
+
+- Summarizing scientific literature
+- Drafting research protocols and study outlines
+- Generating patient-friendly educational material
+- Reviewing clinical documentation for clarity
+- Explaining statistical or computational methods
+- Comparing experimental results
+- Creating data analysis plans
+- Drafting grant or manuscript sections
+- Generating software requirements and code templates
+- Designing test cases and validation checks
+- Summarizing defects, logs, and system behavior
+- Preparing regulatory, operational, or quality reports
+
+However, AI should support professional judgment, not replace it. Researchers must verify evidence. Clinicians must apply medical judgment and follow institutional policy. Engineers must validate code. Testers must confirm system behavior. The output must be reviewed, corrected, and adapted to the real-world context.
+
+
+## Best Practices for Prompt-Based Work
+
+Prompt-based work means using AI prompts to support thinking, drafting, analysis, testing, communication, and documentation. It can be powerful, but it must be controlled carefully, especially in healthcare and scientific environments.
+
+### Provide Source Material
+
+Always provide the relevant source material when accuracy matters. This may include a research abstract, protocol, dataset description, clinical guideline excerpt, requirements document, API specification, test report, or log file. If the model does not have the actual source, it may invent details.
+
+### Separate Facts from Assumptions
+
+Ask the model to separate confirmed facts from assumptions. A useful instruction is:
+
+```text
+List any assumptions separately and do not present them as confirmed facts.
+```
+
+This is important for clinical, scientific, and technical work because unsupported assumptions can lead to incorrect conclusions.
+
+### Ask for Limitations and Uncertainty
+
+For research and healthcare tasks, the model should not only summarize findings but also identify limitations, uncertainty, missing information, and possible bias.
+
+Useful instruction:
+
+```text
+Include a section called Limitations and Uncertainties. Do not overstate the conclusion.
+```
+
+### Use the Right Audience Level
+
+The same topic may need different explanations for different audiences. A physician, patient, researcher, software engineer, tester, executive, and regulatory reviewer may all need different levels of detail.
+
+Example:
+
+```text
+Explain this result twice: first for a clinician, then for a patient with no medical background.
+```
+
+### Review AI Output Manually
+
+AI-generated content may miss domain-specific risks, clinical nuance, statistical limitations, regulatory constraints, data dependencies, or software integration issues. Human review remains essential.
+
+### Use Reusable Prompt Templates
+
+Teams should create standard prompts for common activities such as literature review, protocol drafting, clinical documentation support, patient education, data analysis planning, code review, test case generation, defect analysis, and report writing.
+
+### Validate and Improve Prompts Over Time
+
+If a prompt repeatedly produces incomplete, noisy, or inaccurate results, improve it. Prompt engineering is iterative. Important prompts should be reviewed, versioned, tested, and improved like any other professional asset.
+
+### Protect Sensitive Data
+
+Do not paste production credentials, patient identifiers, protected health information, personal information, proprietary secrets, unpublished research data, or confidential logs into tools that are not approved for that data. Use approved enterprise systems and follow institutional data security policies.
+
+### Avoid Medical Overreach
+
+AI-generated healthcare content should not be treated as a diagnosis, treatment plan, or replacement for licensed clinical judgment. Prompts should explicitly ask the model to avoid definitive medical advice when appropriate.
+
+Example:
+
+```text
+Provide general educational information only. Do not diagnose, prescribe treatment, or replace clinician judgment.
+```
+
+### Measure Usefulness
+
+A prompt is effective if it improves clarity, saves time, reduces ambiguity, supports better decision-making, or improves consistency. The goal is not to use AI for everything, but to use it where it creates measurable value.
+
+
+## Conclusion
+
+Prompt engineering is becoming an important skill for researchers, scientists, doctors, software engineers, testers, data professionals, and healthcare teams. It helps people use AI more effectively for literature review, clinical communication, research planning, documentation, software development, testing, data analysis, and reporting.
+
+Techniques such as zero-shot prompting, few-shot prompting, chain-of-thought prompting, meta prompting, and Tree of Thoughts each serve different purposes. Frameworks such as TAO and CO-STAR make prompts more structured and repeatable.
+
+The most important principle is simple: AI output is only as reliable as the instruction, context, evidence, and review process behind it. In healthcare, research, and technical work, prompt engineering is not just a productivity skill. It is a communication skill, a critical thinking skill, and a professional discipline.

--- a/book/website/artificial-intelligence/prompt-engineering/prompt-templates.md
+++ b/book/website/artificial-intelligence/prompt-engineering/prompt-templates.md
@@ -1,0 +1,42 @@
+# Example Prompt Templates
+
+## Literature Review Prompt
+
+```text
+Act as a biomedical research assistant. Summarize the following article for a research team. Include objective, study design, population, intervention or exposure, comparator, outcomes, key findings, limitations, and implications. Do not add information that is not supported by the text.
+```
+
+## Clinical Explanation Prompt
+
+```text
+Act as a healthcare communication specialist. Explain the following medical concept in patient-friendly language at an eighth-grade reading level. Use plain language, avoid unnecessary jargon, and include a reminder that patients should discuss personal medical decisions with their clinician.
+```
+
+## Research Protocol Prompt
+
+```text
+Act as a clinical research methodologist. Draft an outline for a research protocol based on the following study idea. Include background, objective, study design, population, inclusion criteria, exclusion criteria, outcomes, data collection plan, statistical considerations, limitations, and ethical considerations.
+```
+
+## Data Analysis Prompt
+
+```text
+Act as a biostatistician and data scientist. Review the following dataset description and suggest an analysis plan. Include descriptive analysis, missing data handling, statistical tests or models, assumptions, visualization ideas, and limitations.
+```
+
+## Software Engineering Prompt
+
+```text
+Act as a senior software engineer. Review the following requirement and propose a technical implementation plan. Include architecture considerations, data model changes, APIs, error handling, security concerns, testing strategy, and risks.
+```
+
+## Testing and Validation Prompt
+
+```text
+Act as a test engineer. Generate test cases for the following healthcare software feature. Include functional, negative, security, accessibility, integration, and regression scenarios. Return a table with test ID, scenario, preconditions, steps, expected result, priority, and test type.
+```
+
+### Regulatory or Quality Report Prompt
+
+```text
+Act as a healthcare quality and compliance reviewer. Summarize the following findings for a professional report. Separate facts, assumptions, risks, limitations, and recommended actions. Use concise language and avoid unsupported conclusions.

--- a/book/website/artificial-intelligence/prompt-engineering/types-of-prompting.md
+++ b/book/website/artificial-intelligence/prompt-engineering/types-of-prompting.md
@@ -1,0 +1,104 @@
+# Types of Prompting Techniques
+
+Different prompting techniques are useful for different kinds of tasks. Some are simple and fast, while others are better for complex reasoning, comparison, planning, or structured analysis.
+
+## Zero-Shot Prompting
+
+Zero-shot prompting means asking the model to perform a task without giving examples. The model relies only on the instruction and its general training.
+
+Example:
+
+```text
+Explain the difference between sensitivity and specificity in diagnostic testing.
+```
+
+This technique is useful when the task is common, simple, or exploratory. It works well for quick explanations, first drafts, definitions, summaries, and brainstorming.
+
+Examples across professions:
+
+```text
+Summarize the main limitations of this clinical study.
+```
+
+```text
+Generate a checklist for validating a healthcare data import pipeline.
+```
+
+```text
+Explain this lab result in patient-friendly language at an eighth-grade reading level.
+```
+
+Zero-shot prompting is fast, but the result may be generic. For high-stakes tasks, the output should be refined with source material, constraints, and expert review.
+
+## Few-Shot Prompting
+
+Few-shot prompting means giving the model a few examples before asking it to produce a similar output. This helps the model understand the desired style, format, level of detail, and structure.
+
+Example:
+
+```text
+Here is the format I want:
+
+Finding: Elevated fasting glucose
+Interpretation: May suggest impaired glucose regulation; interpret with clinical context.
+Follow-up: Consider repeat testing or additional evaluation based on clinician judgment.
+
+Now use the same format to explain the following lab findings.
+```
+
+Few-shot prompting is useful when consistency matters. It is helpful for clinical note summaries, literature extraction tables, patient education material, test case design, defect summaries, data review reports, and manuscript editing.
+
+Another example:
+
+```text
+Example output:
+Study Objective: ...
+Population: ...
+Methods: ...
+Key Findings: ...
+Limitations: ...
+
+Now extract the same fields from the following abstract.
+```
+
+## Chain-of-Thought Prompting
+
+Chain-of-thought prompting asks the model to work through a problem step by step. It can be useful for complex analysis, such as evaluating study design, comparing treatment options, reviewing data quality, or identifying possible causes of a software failure.
+
+Example:
+
+```text
+Analyze this research question step by step. Identify the population, intervention, comparator, outcome, study design considerations, possible confounders, and limitations.
+```
+
+In professional usage, it is often better to ask for a concise rationale or structured explanation rather than a long internal reasoning trace. For example:
+
+```text
+Provide your final recommendation and include a brief rationale, key assumptions, and limitations.
+```
+
+This keeps the output useful, reviewable, and concise.
+
+## Meta Prompting
+
+Meta prompting is the technique of asking the model to improve, evaluate, or generate prompts. Instead of directly asking for the final output, the user asks the AI to help design a better prompt for the task.
+
+Example:
+
+```text
+Create a strong prompt that I can use to summarize clinical trial papers. The prompt should require the model to extract study objective, population, intervention, comparator, outcomes, adverse events, limitations, and level of evidence.
+```
+
+Meta prompting is valuable when teams want reusable prompt templates. It helps standardize how AI is used across research, clinical operations, software development, testing, and reporting workflows.
+
+## Tree of Thoughts
+
+Tree of Thoughts is a prompting approach where the model explores multiple possible solution paths before selecting or recommending the best answer. Instead of producing one immediate response, the model considers alternatives.
+
+Example:
+
+```text
+Suggest three possible approaches for analyzing this dataset: a descriptive analysis approach, a statistical modeling approach, and a machine learning approach. Compare the strengths, limitations, assumptions, and risks of each, then recommend the most appropriate approach for a clinical research team.
+```
+
+This technique is useful for complex planning, research design, differential analysis, software architecture decisions, quality strategy, and risk assessment. It encourages broader thinking and reduces the chance of accepting the first obvious answer.


### PR DESCRIPTION
### Checklist

- [x] I agree to follow _The Turing Way_'s [code of conduct](https://book.the-turing-way.org/community-handbook/coc/)
- [ ] I have read the [contribution guide](https://book.the-turing-way.org/community-handbook/contributing/)
- [ ] I have read the [style guide](https://book.the-turing-way.org/community-handbook/style/)

### Summary
Addresses a sub-task in https://github.com/the-turing-way/the-turing-way/issues/4641
In this PR, I've made a start on the chapter about AI and Prompt Engineering

### List of changes proposed in this PR (pull-request)
* Overview of Artificial intelligence
* Brief introduction to prompt engineering 
* Types of prompting techniques
* Frameworks of prompt engineering
* Templates to writing an effective prompt


### What should a reviewer concentrate their feedback on?

- [x] Clarity of content
- [x] Adequate to make into a chapter?
- [x] Everything looks ok?


### Acknowledging contributors

- [ ] All contributors to this pull request are already named in the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/the-turing-way/the-turing-way/blob/main/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
