### PR TITLE
Fix broken Cow20 bibliography link

### DIFF
--- a/book/website/references.bib
+++ b/book/website/references.bib
@@ -458,7 +458,7 @@
   year = {2020},
   month = {Oct},
   note = {Online; accessed 19. Nov. 2020},
-  url = {https://web.archive.org/web/20230321083121/https://libguides.princeton.edu/c.php?g=102546&p=930626}
+  url = {https://researchdata.princeton.edu/research-lifecycle-guide/data-acquisition/file-organization}
 }
 
 @misc{Hodge2015Filenaming,

--- a/book/website/references.bib
+++ b/book/website/references.bib
@@ -458,7 +458,7 @@
   year = {2020},
   month = {Oct},
   note = {Online; accessed 19. Nov. 2020},
-  url = {https://libguides.princeton.edu/c.php?g=102546&p=930626}
+  url = {https://web.archive.org/web/20230321083121/https://libguides.princeton.edu/c.php?g=102546&p=930626}
 }
 
 @misc{Hodge2015Filenaming,


### PR DESCRIPTION
## Summary
- updates the Cow20 bibliography URL to an archived copy of the original Princeton Research Data Management page
- fixes the broken link reported in #3812

## Checks
- confirmed original URL returns 404
- confirmed archived URL returns HTTP 200
- `git diff --check`

Fixes #3812