### PR TITLE
Fix Crossref Funder Registry identifiers in metadata examples

### DIFF
--- a/book/website/communication/citable/citable-metadata.md
+++ b/book/website/communication/citable/citable-metadata.md
@@ -160,8 +160,8 @@ Complete funding metadata includes:
 **Funder Information:**
 - **Funder Name**: The organization providing funding
 - **Funder Identifier**: A persistent identifier for the funder (usually from Crossref Funder Registry)
-  - Example: National Science Foundation = `https://doi.org/10.13039/00000001`
-  - Example: Wellcome Trust = `https://doi.org/10.13039/00000035`
+  - Example: National Science Foundation = `https://doi.org/10.13039/100000001`
+  - Example: Wellcome Trust = `https://doi.org/10.13039/100010269`
 
 **Grant Information:**
 - **Award Number**: The specific grant identifier


### PR DESCRIPTION
Fixes #4696

The two Funder Identifier examples in the citable metadata chapter point to unregistered Crossref Funder Registry IDs:

- `https://doi.org/10.13039/00000001` returns 404 in the Funder Registry API
- `https://doi.org/10.13039/00000035` returns 404 in the Funder Registry API

Corrected to the canonical registry identifiers, verified via direct Funder Registry API lookups:

- `https://doi.org/10.13039/100000001` -> "National Science Foundation"
- `https://doi.org/10.13039/100010269` -> "Wellcome Trust"

Reviewer notes:

- A second Wellcome entry (`10.13039/100004440`) exists in the registry but is deprecated (`replaced-by: 100010269`); `100010269` is the current canonical record.
- The funder labels ("National Science Foundation", "Wellcome Trust") already match the registry names and are unchanged.
- No formatting changes; only the identifier digits inside the two example URLs are updated.