### PR TITLE
Fix dead Turndown demo link in consistency-formatting (moved to mixmark-io.github.io)

### DIFF
--- a/book/website/community-handbook/style/consistency/consistency-formatting.md
+++ b/book/website/community-handbook/style/consistency/consistency-formatting.md
@@ -46,7 +46,7 @@ Converting HTML to {term}`Markdown` makes The Turing Way book easier to read.
 
 Chapter content written in `HTML` are usually enclosed in tags which begin and end with angle brackets `<>`.
 [W3Schools](https://www.w3schools.com/html/html_elements.asp) is an excellent resource for understanding what these tags mean, and {term}`Markdown` reference guides, such as [this cheatsheet](https://www.markdownguide.org/cheat-sheet/), can help translate `HTML` formatting to Markdown.
-There are also helpful tools on the web, such as [Turndown](https://domchristie.github.io/turndown/) and [CloudConvert](https://cloudconvert.com/html-to-md), that convert `HTML` to {term}`Markdown` with a single click.
+There are also helpful tools on the web, such as [Turndown](https://mixmark-io.github.io/turndown/), [CloudConvert](https://cloudconvert.com/html-to-md) and [file2markdown](https://www.file2markdown.ai/convert/html-to-markdown), that convert `HTML` to {term}`Markdown` with a single click.
 
 Please note that if `HTML` is the only option for you to format your text the way you desire, you can use it only if the content in the online book can still be read and understood (use the Netlify preview in your PR to test).
 For example, [superscripts and subscripts](https://support.squarespace.com/hc/en-us/articles/206543587-Markdown-cheat-sheet#toc-superscript-and-subscript) can be written in `HTML` because they always appear as intended.


### PR DESCRIPTION
### Checklist

- [x] I agree to follow _The Turing Way_'s [code of conduct](https://book.the-turing-way.org/community-handbook/coc/)
- [x] I have read the [contribution guide](https://book.the-turing-way.org/community-handbook/contributing/)
- [x] I have read the [style guide](https://book.the-turing-way.org/community-handbook/style/)

### Summary

The HTML-to-Markdown paragraph in `consistency-formatting.md` links the Turndown demo at `domchristie.github.io/turndown/`, which now returns 404 (the project moved to the mixmark-io org; the live demo is https://mixmark-io.github.io/turndown/). This PR updates that link and adds one more browser-based converter, [file2markdown](https://www.file2markdown.ai/convert/html-to-markdown), alongside CloudConvert.

Disclosure: I maintain file2markdown; happy to drop that addition if it doesn't fit the list's criteria.

### What should a reviewer concentrate their feedback on?

Whether the extra tool mention is welcome; the link fix stands on its own.

### Acknowledging contributors

No other contributors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)